### PR TITLE
[style] Implement a consistent code style

### DIFF
--- a/adbfs.cpp
+++ b/adbfs.cpp
@@ -24,13 +24,13 @@
 
    @code fusermount -u mountpoint @endcode
 
-   as usual for FUSE.  
+   as usual for FUSE.
 
    The above assumes you have a fairly standard Android development
    setup, with adb in the path, busybox available on the Android
    device, etc.  Everything is very lightly tested and a work in
    progress.  Read the source and use with caution.
-   
+
 */
 
 /*
@@ -47,7 +47,7 @@
  *      Redistribution and use in source and binary forms, with or without
  *      modification, are permitted provided that the following conditions are
  *      met:
- *      
+ *
  *      * Redistributions of source code must retain the above copyright
  *        notice, this list of conditions and the following disclaimer.
  *      * Redistributions in binary form must reproduce the above
@@ -57,7 +57,7 @@
  *      * Neither the name of the  nor the names of its
  *        contributors may be used to endorse or promote products derived from
  *        this software without specific prior written permission.
- *      
+ *
  *      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  *      "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  *      LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -70,30 +70,30 @@
  *      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  *      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 #define FUSE_USE_VERSION 26
 #include "utils.h"
 
 #include <execinfo.h>
+#include <grp.h>
+#include <pwd.h>
 #include <signal.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <pwd.h>
-#include <grp.h>
 
-void handler(int sig) {
-  void *array[10];
-  size_t size;
+void handler(int sig)
+{
+    void* array[10];
+    size_t size;
 
-  // get void*'s for all entries on the stack
-  size = backtrace(array, 10);
+    // get void*'s for all entries on the stack
+    size = backtrace(array, 10);
 
-  // print out all the frames to stderr
-  fprintf(stderr, "Error: signal %d:\n", sig);
-  backtrace_symbols_fd(array, size, 2);
-  exit(1);
+    // print out all the frames to stderr
+    fprintf(stderr, "Error: signal %d:\n", sig);
+    backtrace_symbols_fd(array, size, 2);
+    exit(1);
 }
-
 
 using namespace std;
 
@@ -107,16 +107,17 @@ queue<string> shell(const string&);
 static const char PERMISSION_ERR_MSG[] = ": Permission denied";
 
 string tempDirPath;
-map<string,fileCache> fileData;
-void invalidateCache(const string& path) {
-    cout << "invalidate cache " << path << endl;    
+map<string, fileCache> fileData;
+void invalidateCache(const string& path)
+{
+    cout << "invalidate cache " << path << endl;
     map<string, fileCache>::iterator it = fileData.find(path);
-    if (it != fileData.end()) 
+    if (it != fileData.end())
         fileData.erase(it);
 }
 
-map<int,bool> filePendingWrite;
-map<string,bool> fileTruncated;
+map<int, bool> filePendingWrite;
+map<string, bool> fileTruncated;
 
 /**
    Return the result of executing the given command string, using
@@ -129,7 +130,7 @@ queue<string> shell(const string& command)
 {
     string actual_command;
     actual_command.assign(command);
-    //shell_escape_command(actual_command);
+    // shell_escape_command(actual_command);
     return exec_command(actual_command);
 }
 
@@ -148,7 +149,7 @@ queue<string> adb_shell(const string& command)
 {
     string actual_command;
     actual_command.assign(command);
-    //adb_shell_escape_command(actual_command);
+    // adb_shell_escape_command(actual_command);
     actual_command.insert(0, "adb shell \"");
     actual_command.append("\"");
     return exec_command(actual_command);
@@ -164,9 +165,9 @@ queue<string> adb_shell(const string& command)
  */
 void shell_escape_command(string& cmd)
 {
-    string_replacer(cmd,"\\","\\\\");
-    string_replacer(cmd,"'","\\'");
-    string_replacer(cmd,"`","\\`");
+    string_replacer(cmd, "\\", "\\\\");
+    string_replacer(cmd, "'", "\\'");
+    string_replacer(cmd, "`", "\\`");
 }
 
 /**
@@ -179,38 +180,38 @@ void shell_escape_command(string& cmd)
  */
 void adb_shell_escape_command(string& cmd)
 {
-    string_replacer(cmd,"\\","\\\\");
-    string_replacer(cmd,"(","\\(");
-    string_replacer(cmd,")","\\)");
-    string_replacer(cmd,"'","\\'");
-    string_replacer(cmd,"`","\\`");
-    string_replacer(cmd,"|","\\|");
-    string_replacer(cmd,"&","\\&");
-    string_replacer(cmd,";","\\;");
-    string_replacer(cmd,"<","\\<");
-    string_replacer(cmd,">","\\>");
-    string_replacer(cmd,"*","\\*");
-    string_replacer(cmd,"#","\\#");
-    string_replacer(cmd,"%","\\%");
-    string_replacer(cmd,"=","\\=");
-    string_replacer(cmd,"~","\\~");
-    string_replacer(cmd,"/[0;0m","");
-    string_replacer(cmd,"/[1;32m","");
-    string_replacer(cmd,"/[1;34m","");
-    string_replacer(cmd,"/[1;36m","");
+    string_replacer(cmd, "\\", "\\\\");
+    string_replacer(cmd, "(", "\\(");
+    string_replacer(cmd, ")", "\\)");
+    string_replacer(cmd, "'", "\\'");
+    string_replacer(cmd, "`", "\\`");
+    string_replacer(cmd, "|", "\\|");
+    string_replacer(cmd, "&", "\\&");
+    string_replacer(cmd, ";", "\\;");
+    string_replacer(cmd, "<", "\\<");
+    string_replacer(cmd, ">", "\\>");
+    string_replacer(cmd, "*", "\\*");
+    string_replacer(cmd, "#", "\\#");
+    string_replacer(cmd, "%", "\\%");
+    string_replacer(cmd, "=", "\\=");
+    string_replacer(cmd, "~", "\\~");
+    string_replacer(cmd, "/[0;0m", "");
+    string_replacer(cmd, "/[1;32m", "");
+    string_replacer(cmd, "/[1;34m", "");
+    string_replacer(cmd, "/[1;36m", "");
 }
 
 /**
    Modify, in place, the given path string by escaping special characters.
-   
+
    @param path the string to modify.
    @see shell_escape_command.
    @todo check/simplify escaping.
  */
-void shell_escape_path(string &path)
+void shell_escape_path(string& path)
 {
-  string_replacer(path, "'", "'\\''");
-  string_replacer(path, "\"", "\\\"");
+    string_replacer(path, "'", "'\\''");
+    string_replacer(path, "\"", "\\\"");
 }
 
 /**
@@ -219,14 +220,16 @@ void shell_escape_path(string &path)
 
    Also set up a callback to cleanup after ourselves on clean shutdown.
  */
-void cleanupTmpDir(void) {
+void cleanupTmpDir(void)
+{
     string command = "rm -rf ";
     command.append(tempDirPath);
     shell(command);
 }
 
-void makeTmpDir(void) {
-    char adbfsTemplate[]="/tmp/adbfs-XXXXXX";
+void makeTmpDir(void)
+{
+    char adbfsTemplate[] = "/tmp/adbfs-XXXXXX";
     tempDirPath.assign(mkdtemp(adbfsTemplate));
     tempDirPath.append("/");
     atexit(&cleanupTmpDir);
@@ -234,7 +237,7 @@ void makeTmpDir(void) {
 
 /**
    Set a given string to an adb push or pull command with given paths.
-   
+
    @param cmd string to which the adb command is written.
    @param push true for a push command, false for pull.
    @param local_path path on local host for push or pull command.
@@ -242,8 +245,8 @@ void makeTmpDir(void) {
    @see adb_pull.
    @see adb_push.
  */
-void adb_push_pull_cmd(string& cmd, const bool push, 
-		       const string& local_path, const string& remote_path)
+void adb_push_pull_cmd(string& cmd, const bool push, const string& local_path,
+                       const string& remote_path)
 {
     cmd.assign("adb ");
     cmd.append((push ? "push '" : "pull '"));
@@ -266,7 +269,7 @@ void adb_push_pull_cmd(string& cmd, const bool push,
    @bug problems with files with spaces in filenames (adb bug?)
  */
 queue<string> adb_pull(const string& remote_source,
-		       const string& local_destination)
+                       const string& local_destination)
 {
     string cmd;
     adb_push_pull_cmd(cmd, false, local_destination, remote_source);
@@ -282,7 +285,7 @@ queue<string> adb_pull(const string& remote_source,
    @bug problems with files with spaces in filenames (adb bug?)
  */
 queue<string> adb_push(const string& local_source,
-		       const string& remote_destination)
+                       const string& remote_destination)
 {
     string cmd;
     adb_push_pull_cmd(cmd, true, local_source, remote_destination);
@@ -296,82 +299,91 @@ queue<string> adb_push(const string& local_source,
    @todo check shell escaping.
  */
 
-
-
-int strmode_to_rawmode(const string& str) {
+int strmode_to_rawmode(const string& str)
+{
     int fmode = 0;
-    switch (str[0]) {
-    case 's': fmode |= S_IFSOCK; break;
-    case 'l': fmode |= S_IFLNK; break;
-    case '-': fmode |= S_IFREG; break;
-    case 'd': fmode |= S_IFDIR; break;
-    case 'b': fmode |= S_IFBLK; break;
-    case 'c': fmode |= S_IFCHR; break;
-    case 'p': fmode |= S_IFIFO; break;
-    }
-   
-    if (str[1] == 'r') fmode |= S_IRUSR;
-    if (str[2] == 'w') fmode |= S_IWUSR;
-    switch (str[3]) {
-    case 'x': fmode |= S_IXUSR; break;
-    case 's': fmode |= S_ISUID | S_IXUSR; break;
-    case 'S': fmode |= S_ISUID; break;
+    switch (str[0])
+    {
+        case 's': fmode |= S_IFSOCK; break;
+        case 'l': fmode |= S_IFLNK; break;
+        case '-': fmode |= S_IFREG; break;
+        case 'd': fmode |= S_IFDIR; break;
+        case 'b': fmode |= S_IFBLK; break;
+        case 'c': fmode |= S_IFCHR; break;
+        case 'p': fmode |= S_IFIFO; break;
     }
 
-    if (str[4] == 'r') fmode |= S_IRGRP;
-    if (str[5] == 'w') fmode |= S_IWGRP;
-    switch (str[6]) {
-    case 'x': fmode |= S_IXGRP; break;
-    case 's': fmode |= S_ISGID | S_IXGRP; break;
-    case 'S': fmode |= S_ISGID; break;
+    if (str[1] == 'r')
+        fmode |= S_IRUSR;
+    if (str[2] == 'w')
+        fmode |= S_IWUSR;
+    switch (str[3])
+    {
+        case 'x': fmode |= S_IXUSR; break;
+        case 's': fmode |= S_ISUID | S_IXUSR; break;
+        case 'S': fmode |= S_ISUID; break;
     }
-    
-    if (str[7] == 'r') fmode |= S_IROTH;
-    if (str[8] == 'w') fmode |= S_IWOTH;
-    switch (str[9]) {
-    case 'x': fmode |= S_IXOTH; break;
-    case 't': fmode |= S_ISVTX | S_IXOTH; break;
-    case 'T': fmode |= S_ISVTX; break;
+
+    if (str[4] == 'r')
+        fmode |= S_IRGRP;
+    if (str[5] == 'w')
+        fmode |= S_IWGRP;
+    switch (str[6])
+    {
+        case 'x': fmode |= S_IXGRP; break;
+        case 's': fmode |= S_ISGID | S_IXGRP; break;
+        case 'S': fmode |= S_ISGID; break;
+    }
+
+    if (str[7] == 'r')
+        fmode |= S_IROTH;
+    if (str[8] == 'w')
+        fmode |= S_IWOTH;
+    switch (str[9])
+    {
+        case 'x': fmode |= S_IXOTH; break;
+        case 't': fmode |= S_ISVTX | S_IXOTH; break;
+        case 'T': fmode |= S_ISVTX; break;
     }
 
     return fmode;
 
-        // In octal,
-        //     // 40XXX is folder, 100xxx is file
-        //         // xxx is regular mode e.g. 755 = -rwxr-xr-x
-        //
-
+    // In octal,
+    // 40XXX is folder, 100xxx is file
+    // xxx is regular mode e.g. 755 = -rwxr-xr-x
 }
 
 // Heuristic to determine whether the output of ls produced
 // an actual file
-bool is_valid_ls_output(const string& file) {
-  /* The specific error messages we are looking for (from the android source)-
-     (in listdir) "opendir failed, strerror"
-     (in show_total_size) "stat failed on filename, strerror"
-     (in listfile_size) "lstat 'filename' failed: strerror"
+bool is_valid_ls_output(const string& file)
+{
+    /* The specific error messages we are looking for (from the android source)-
+       (in listdir) "opendir failed, strerror"
+       (in show_total_size) "stat failed on filename, strerror"
+       (in listfile_size) "lstat 'filename' failed: strerror"
 
-     Thus, we can abuse this a little and just make sure that the second
-     character is either "r" or "-", and assume it's an error otherwise.
+       Thus, we can abuse this a little and just make sure that the second
+       character is either "r" or "-", and assume it's an error otherwise.
 
-     To eliminate cases such as /rfile: no such file or directory from
-     producing false-positives, we also check whether the first character
-     is a slash
+       To eliminate cases such as /rfile: no such file or directory from
+       producing false-positives, we also check whether the first character
+       is a slash
 
-     It'd be really nice if we could actually take the strerrors and convert
-     them back to codes, but I fear that involves undoing localization.
-  */
-  if (file[0] == '/') return false;
-  if (file[1] != 'r' && file[1] != '-') return false;
-  return true;
+       It'd be really nice if we could actually take the strerrors and convert
+       them back to codes, but I fear that involves undoing localization.
+    */
+    if (file[0] == '/')
+        return false;
+    if (file[1] != 'r' && file[1] != '-')
+        return false;
+    return true;
 }
 
-static int adb_getattr(const char *path, struct stat *stbuf)
+static int adb_getattr(const char* path, struct stat* stbuf)
 {
-
     int res = 0;
-    struct passwd * foruid;
-    struct group * forgid;
+    struct passwd* foruid;
+    struct group* forgid;
     memset(stbuf, 0, sizeof(struct stat));
     queue<string> output;
     string path_string;
@@ -380,34 +392,44 @@ static int adb_getattr(const char *path, struct stat *stbuf)
     // TODO /caching?
     //
     vector<string> output_chunk;
-    if (fileData.find(path_string) ==  fileData.end() 
-	|| fileData[path_string].timestamp + 30 < time(NULL)) {
+    if (fileData.find(path_string) == fileData.end() ||
+        fileData[path_string].timestamp + 30 < time(NULL))
+    {
         string command = "ls -l -a -d '";
         command.append(path_string);
         command.append("'");
         output = adb_shell(command);
-        if (output.empty()) return -EAGAIN; /* no phone */
+        if (output.empty())
+            return -EAGAIN; /* no phone */
         // error format: "/sbin/healthd: Permission denied"
-        if (!output.front().compare(output.front().length() - sizeof(PERMISSION_ERR_MSG) + 1,
-                                    sizeof(PERMISSION_ERR_MSG) - 1, PERMISSION_ERR_MSG))
+        if (!output.front().compare(
+                output.front().length() - sizeof(PERMISSION_ERR_MSG) + 1,
+                sizeof(PERMISSION_ERR_MSG) - 1, PERMISSION_ERR_MSG))
         {
             fileData[path_string].statOutput.erase();
-        } else {
-            output_chunk = make_array(output.front());
+        }
+        else
+        {
+            output_chunk                     = make_array(output.front());
             fileData[path_string].statOutput = output.front();
         }
         fileData[path_string].timestamp = time(NULL);
-    } else{
+    }
+    else
+    {
         output_chunk = make_array(fileData[path_string].statOutput);
         cout << "from cache " << path << "\n";
     }
-    if (fileData[path_string].statOutput.empty()) {
+
+    if (fileData[path_string].statOutput.empty())
+    {
         // return empty structure - file exists, but no info available
         stbuf->st_mode = S_IFREG;
         return res;
     }
 
-    if(!is_valid_ls_output(output_chunk[0])) {
+    if (!is_valid_ls_output(output_chunk[0]))
+    {
         return -ENOENT;
     }
 
@@ -415,7 +437,8 @@ static int adb_getattr(const char *path, struct stat *stbuf)
     // ls -lad explained
     // -rw-rw-r-- root     sdcard_rw   763362 2012-06-22 02:16 file.html
     //
-    //stbuf->st_dev = atoi(output_chunk[1].c_str());     /* ID of device containing file */
+    // stbuf->st_dev = atoi(output_chunk[1].c_str()); /* ID of device containing
+    // file */
     //
     // In octal,
     // 40XXX is folder, 100xxx is file
@@ -423,116 +446,123 @@ static int adb_getattr(const char *path, struct stat *stbuf)
     //
 
     stbuf->st_ino = 1; // atoi(output_chunk[7].c_str());     /* inode number */
-    //stbuf->st_mode = raw_mode | 0700;    /* protection */
+    // stbuf->st_mode = raw_mode | 0700;    /* protection */
     stbuf->st_mode = strmode_to_rawmode(output_chunk[0]);
 
-    stbuf->st_nlink = 1;   /* number of hard links */
+    stbuf->st_nlink = 1; /* number of hard links */
 
     foruid = getpwnam(output_chunk[1].c_str());
     if (foruid)
-	    stbuf->st_uid = foruid->pw_uid;     /* user ID of owner */
+        stbuf->st_uid = foruid->pw_uid; /* user ID of owner */
     else
-	    stbuf->st_uid = 98; /* 98 has been chosen (poorly) so that it doesn't map to anything */
+        stbuf->st_uid = 98; /* 98 has been chosen (poorly) so that it doesn't
+                               map to anything */
 
     forgid = getgrnam(output_chunk[2].c_str());
     if (forgid)
-	    stbuf->st_gid = forgid->gr_gid;     /* group ID of owner */
+        stbuf->st_gid = forgid->gr_gid; /* group ID of owner */
     else
-	    stbuf->st_gid = 98;
+        stbuf->st_gid = 98;
 
-    //unsigned int device_id;
-    //xtoi(output_chunk[6].c_str(),&device_id);
-    //stbuf->st_rdev = device_id;    // device ID (if special file)
+    // unsigned int device_id;
+    // xtoi(output_chunk[6].c_str(),&device_id);
+    // stbuf->st_rdev = device_id; // device ID (if special file)
 
     int iDate;
 
-    switch (stbuf->st_mode & S_IFMT) {
-    case S_IFBLK:
-    case S_IFCHR:
-	    stbuf->st_rdev = atoi(output_chunk[3].c_str()) * 256 + atoi(output_chunk[4].c_str());
-	    stbuf->st_size = 0;
-	    iDate = 5;
-	    break;
+    switch (stbuf->st_mode & S_IFMT)
+    {
+        case S_IFBLK:
+        case S_IFCHR:
+            stbuf->st_rdev = atoi(output_chunk[3].c_str()) * 256 +
+                             atoi(output_chunk[4].c_str());
+            stbuf->st_size = 0;
+            iDate          = 5;
+            break;
 
-	    break;
+            break;
 
-    case S_IFREG:
-	    stbuf->st_size = atoi(output_chunk[3].c_str());    /* total size, in bytes */
-	    iDate = 4;
-	    break;
+        case S_IFREG:
+            stbuf->st_size =
+                atoi(output_chunk[3].c_str()); /* total size, in bytes */
+            iDate = 4;
+            break;
 
-    default:
-    case S_IFSOCK:
-    case S_IFIFO:
-    case S_IFLNK:
-    case S_IFDIR:
-	    stbuf->st_size = 0;
-	    iDate = 3;
-	    break;
+        default:
+        case S_IFSOCK:
+        case S_IFIFO:
+        case S_IFLNK:
+        case S_IFDIR:
+            stbuf->st_size = 0;
+            iDate          = 3;
+            break;
     }
 
     stbuf->st_blksize = 0; // TODO: THIS IS SMELLY
-    stbuf->st_blocks = 1;
+    stbuf->st_blocks  = 1;
 
-    //for (int k = 0; k < output_chunk.size(); ++k) cout << output_chunk[k] << " ";    
-    //cout << endl;
-    
+    // for (int k = 0; k < output_chunk.size(); ++k) cout << output_chunk[k] <<
+    // " ";
+    // cout << endl;
 
     vector<string> ymd = make_array(output_chunk[iDate], "-");
-    vector<string> hm = make_array(output_chunk[iDate + 1], ":");
+    vector<string> hm  = make_array(output_chunk[iDate + 1], ":");
 
-
-    //for (int k = 0; k < ymd.size(); ++k) cout << ymd[k] << " ";
-    //cout << endl;
-    //for (int k = 0; k <  hm.size(); ++k) cout <<  hm[k] << " ";
-    //cout << endl;
+    // for (int k = 0; k < ymd.size(); ++k) cout << ymd[k] << " ";
+    // cout << endl;
+    // for (int k = 0; k <  hm.size(); ++k) cout <<  hm[k] << " ";
+    // cout << endl;
     struct tm ftime;
-    ftime.tm_year = atoi(ymd[0].c_str()) - 1900;
-    ftime.tm_mon  = atoi(ymd[1].c_str()) - 1;
-    ftime.tm_mday = atoi(ymd[2].c_str());
-    ftime.tm_hour = atoi(hm[0].c_str());
-    ftime.tm_min  = atoi(hm[1].c_str());
-    ftime.tm_sec  = 0;
+    ftime.tm_year  = atoi(ymd[0].c_str()) - 1900;
+    ftime.tm_mon   = atoi(ymd[1].c_str()) - 1;
+    ftime.tm_mday  = atoi(ymd[2].c_str());
+    ftime.tm_hour  = atoi(hm[0].c_str());
+    ftime.tm_min   = atoi(hm[1].c_str());
+    ftime.tm_sec   = 0;
     ftime.tm_isdst = -1;
-    time_t now = mktime(&ftime);
-    //cout << "after mktime" << endl;
+    time_t now     = mktime(&ftime);
+    // cout << "after mktime" << endl;
 
-    //long now = time(0);
+    // long now = time(0);
 
-    stbuf->st_atime = now;   /* time of last access */
-    //stbuf->st_atime = atol(output_chunk[11].c_str());   /* time of last access */
-    stbuf->st_mtime = now;   /* time of last modification */
-    //stbuf->st_mtime = atol(output_chunk[12].c_str());   /* time of last modification */
-    stbuf->st_ctime = now;   /* time of last status change */
-    //stbuf->st_ctime = atol(output_chunk[13].c_str());   /* time of last status change */
+    stbuf->st_atime = now; /* time of last access */
+    // stbuf->st_atime = atol(output_chunk[11].c_str());   /* time of last
+    // access */
+    stbuf->st_mtime = now; /* time of last modification */
+    // stbuf->st_mtime = atol(output_chunk[12].c_str());   /* time of last
+    // modification */
+    stbuf->st_ctime = now; /* time of last status change */
+    // stbuf->st_ctime = atol(output_chunk[13].c_str());   /* time of last
+    // status change */
     return res;
 }
 
-
-size_t find_nth(int n, const string& substr, const string& corpus) {
+size_t find_nth(int n, const string& substr, const string& corpus)
+{
     size_t p = 0;
-    while (n--) {
-        if ((( p = corpus.find_first_of(substr, p) )) == string::npos) return string::npos;
-        p = corpus.find_first_not_of(substr, p); 
-    }   
+    while (n--)
+    {
+        if (((p = corpus.find_first_of(substr, p))) == string::npos)
+            return string::npos;
+        p = corpus.find_first_not_of(substr, p);
+    }
     return p;
 }
-
 
 /**
    adbFS implementation of FUSE interface function fuse_operations.readdir.
    @todo check shell escaping.
  */
-static int adb_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
-    off_t offset, struct fuse_file_info *fi)
+static int adb_readdir(const char* path, void* buf, fuse_fill_dir_t filler,
+                       off_t offset, struct fuse_file_info* fi)
 {
-    (void) offset;
-    (void) fi;
+    (void)offset;
+    (void)fi;
     string path_string;
     string local_path_string;
     path_string.assign(path);
     local_path_string = tempDirPath;
-    string_replacer(path_string,"/","-");
+    string_replacer(path_string, "/", "-");
     local_path_string.append(path_string);
     path_string.assign(path);
 
@@ -545,55 +575,65 @@ static int adb_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
     output = adb_shell(command);
 
     /* cannot tell between "no phone" and "empty directory" */
-    while (output.size() > 0) {
+    while (output.size() > 0)
+    {
         // skip lines too short to process (should not happen)
-        if (output.front().length() >= 3) {
-            // we can get e.g. "permission denied" during listing, need to check every line separately
-            if (!is_valid_ls_output(output.front())) {
+        if (output.front().length() >= 3)
+        {
+            // we can get e.g. "permission denied" during listing, need to check
+            // every line separately
+            if (!is_valid_ls_output(output.front()))
+            {
                 // error format: "lstat '//efs' failed: Permission denied"
-                if (!output.front().compare(output.front().length() - sizeof(PERMISSION_ERR_MSG) + 1,
-                                            sizeof(PERMISSION_ERR_MSG) - 1, PERMISSION_ERR_MSG)) {
-                    size_t nameStart = output.front().rfind("/") + 1;
-                    const string& fname_l = output.front().substr(nameStart, output.front().find("' ") - nameStart);
+                if (!output.front().compare(output.front().length() -
+                                                sizeof(PERMISSION_ERR_MSG) + 1,
+                                            sizeof(PERMISSION_ERR_MSG) - 1,
+                                            PERMISSION_ERR_MSG))
+                {
+                    size_t nameStart      = output.front().rfind("/") + 1;
+                    const string& fname_l = output.front().substr(
+                        nameStart, output.front().find("' ") - nameStart);
                     filler(buf, fname_l.c_str(), NULL, 0);
-                    const string& path_string_c = path_string
-                        + (path_string == "/" ? "" : "/") + fname_l;
+                    const string& path_string_c =
+                        path_string + (path_string == "/" ? "" : "/") + fname_l;
 
-                    cout << "caching " << path_string_c << " = " << output.front() <<  endl;
+                    cout << "caching " << path_string_c << " = "
+                         << output.front() << endl;
                     fileData[path_string_c].statOutput.erase();
                     fileData[path_string_c].timestamp = time(NULL);
                     cout << "cached " << endl;
                 }
-            } else {
+            }
+            else
+            {
                 // Start of filename = `ls -la` time separator + 4
-                size_t nameStart = output.front().find_first_of(":") + 4;
+                size_t nameStart      = output.front().find_first_of(":") + 4;
                 const string& fname_l = output.front().substr(nameStart);
-                const string fname_n = fname_l.substr(0, fname_l.find(" -> "));
+                const string fname_n  = fname_l.substr(0, fname_l.find(" -> "));
                 filler(buf, fname_n.c_str(), NULL, 0);
-                const string path_string_c = path_string
-                    + (path_string == "/" ? "" : "/") + fname_n;
+                const string path_string_c =
+                    path_string + (path_string == "/" ? "" : "/") + fname_n;
 
-                cout << "caching " << path_string_c << " = " << output.front() <<  endl;
+                cout << "caching " << path_string_c << " = " << output.front()
+                     << endl;
                 fileData[path_string_c].statOutput = output.front();
-                fileData[path_string_c].timestamp = time(NULL);
+                fileData[path_string_c].timestamp  = time(NULL);
                 cout << "cached " << endl;
             }
         }
         output.pop();
     }
 
-
     return 0;
 }
 
-
-static int adb_open(const char *path, struct fuse_file_info *fi)
+static int adb_open(const char* path, struct fuse_file_info* fi)
 {
     string path_string;
     string local_path_string;
     path_string.assign(path);
     local_path_string = tempDirPath;
-    string_replacer(path_string,"/","-");
+    string_replacer(path_string, "/", "-");
     local_path_string.append(path_string);
 
     string filehandle_path = local_path_string;
@@ -603,26 +643,30 @@ static int adb_open(const char *path, struct fuse_file_info *fi)
     shell_escape_path(local_path_string);
 
     cout << "-- adb_open --" << path_string << " " << local_path_string << "\n";
-    if (!fileTruncated[path_string]){
+    if (!fileTruncated[path_string])
+    {
         queue<string> output;
         string command = "ls -l -a -d '";
         command.append(path_string);
         command.append("'");
-        cout << command<<"\n";
-        output = adb_shell(command);
+        cout << command << "\n";
+        output                      = adb_shell(command);
         vector<string> output_chunk = make_array(output.front());
-        if (!is_valid_ls_output(output_chunk[0])) {
-          return -ENOENT;
+        if (!is_valid_ls_output(output_chunk[0]))
+        {
+            return -ENOENT;
         }
         path_string.assign(path);
         local_path_string = tempDirPath;
-        string_replacer(path_string,"/","-");
+        string_replacer(path_string, "/", "-");
         local_path_string.append(path_string);
         path_string.assign(path);
         shell_escape_path(path_string);
         shell_escape_path(local_path_string);
-        adb_pull(path_string,local_path_string);
-    } else {
+        adb_pull(path_string, local_path_string);
+    }
+    else
+    {
         fileTruncated[path_string] = false;
     }
 
@@ -631,48 +675,51 @@ static int adb_open(const char *path, struct fuse_file_info *fi)
     return 0;
 }
 
-static int adb_read(const char *path, char *buf, size_t size, off_t offset,
-    struct fuse_file_info *fi)
+static int adb_read(const char* path, char* buf, size_t size, off_t offset,
+                    struct fuse_file_info* fi)
 {
     int fd;
     int res;
-    fd = fi->fh; //open(local_path_string.c_str(), O_RDWR);
-    if(fd == -1)
+    fd = fi->fh; // open(local_path_string.c_str(), O_RDWR);
+    if (fd == -1)
         return -errno;
     res = pread(fd, buf, size, offset);
-    //close(fd);
-    if(res == -1)
+    // close(fd);
+    if (res == -1)
         res = -errno;
 
     return res;
 }
 
-static int adb_write(const char *path, const char *buf, size_t size, off_t offset, struct fuse_file_info *fi) {
-    //string path_string;
-    //string local_path_string;
-    //path_string.assign(path);
-    //shell_escape_path(path_string);
+static int adb_write(const char* path, const char* buf, size_t size,
+                     off_t offset, struct fuse_file_info* fi)
+{
+    // string path_string;
+    // string local_path_string;
+    // path_string.assign(path);
+    // shell_escape_path(path_string);
 
-    int fd = fi->fh; //open(local_path_string.c_str(), O_CREAT|O_RDWR|O_TRUNC);
+    // open(local_path_string.c_str(), O_CREAT|O_RDWR|O_TRUNC);
+    int fd = fi->fh;
 
     filePendingWrite[fd] = true;
 
     int res = pwrite(fd, buf, size, offset);
-    //close(fd);
-    //adb_push(local_path_string,path_string);
-    //adb_shell("sync");
+    // close(fd);
+    // adb_push(local_path_string,path_string);
+    // adb_shell("sync");
     if (res == -1)
         res = -errno;
     return res;
 }
 
-
-static int adb_flush(const char *path, struct fuse_file_info *fi) {
+static int adb_flush(const char* path, struct fuse_file_info* fi)
+{
     string path_string;
     string local_path_string;
     path_string.assign(path);
     local_path_string = tempDirPath;
-    string_replacer(path_string,"/","-");
+    string_replacer(path_string, "/", "-");
     local_path_string.append(path_string);
     path_string.assign(path);
 
@@ -680,10 +727,11 @@ static int adb_flush(const char *path, struct fuse_file_info *fi) {
     shell_escape_path(local_path_string);
 
     int flags = fi->flags;
-    int fd = fi->fh;
-    cout << "flag is: "<< flags <<"\n";
+    int fd    = fi->fh;
+    cout << "flag is: " << flags << "\n";
     invalidateCache(path_string);
-    if (filePendingWrite[fd]) {
+    if (filePendingWrite[fd])
+    {
         filePendingWrite[fd] = false;
         adb_push(local_path_string, path_string);
         adb_shell("sync");
@@ -691,25 +739,28 @@ static int adb_flush(const char *path, struct fuse_file_info *fi) {
     return 0;
 }
 
-static int adb_release(const char *path, struct fuse_file_info *fi) {
+static int adb_release(const char* path, struct fuse_file_info* fi)
+{
     int fd = fi->fh;
     filePendingWrite.erase(filePendingWrite.find(fd));
     close(fd);
     return 0;
 }
 
-static int adb_access(const char *path, int mask) {
+static int adb_access(const char* path, int mask)
+{
     //###cout << "###access[path=" << path << "]" <<  endl;
     return 0;
 }
 
-static int adb_utimens(const char *path, const struct timespec ts[2]) {
+static int adb_utimens(const char* path, const struct timespec ts[2])
+{
     string path_string;
     string local_path_string;
     path_string.assign(path);
     fileData[path_string].timestamp = fileData[path_string].timestamp + 50;
-    local_path_string = tempDirPath;
-    string_replacer(path_string,"/","-");
+    local_path_string               = tempDirPath;
+    string_replacer(path_string, "/", "-");
     local_path_string.append(path_string);
     path_string.assign(path);
 
@@ -720,61 +771,64 @@ static int adb_utimens(const char *path, const struct timespec ts[2]) {
     string command = "touch '";
     command.append(path_string);
     command.append("'");
-    cout << command<<"\n";
+    cout << command << "\n";
     adb_shell(command);
 
     return 0;
 }
 
-static int adb_truncate(const char *path, off_t size) {
+static int adb_truncate(const char* path, off_t size)
+{
     string path_string;
     string local_path_string;
     path_string.assign(path);
     fileData[path_string].timestamp = fileData[path_string].timestamp + 50;
-    local_path_string = tempDirPath;
-    string_replacer(path_string,"/","-");
+    local_path_string               = tempDirPath;
+    string_replacer(path_string, "/", "-");
     local_path_string.append(path_string);
     path_string.assign(path);
     shell_escape_path(path_string);
     shell_escape_path(local_path_string);
-
 
     queue<string> output;
     string command = "ls -l -a -d '";
     command.append(path_string);
     command.append("'");
     cout << command << "\n";
-    output = adb_shell(command);
+    output                      = adb_shell(command);
     vector<string> output_chunk = make_array(output.front());
-    if (output_chunk[0][0] == '/'){
-        adb_pull(path_string,local_path_string);
+    if (output_chunk[0][0] == '/')
+    {
+        adb_pull(path_string, local_path_string);
     }
 
     fileTruncated[path_string] = true;
 
     invalidateCache(path_string);
-    
-    cout << "truncate[path=" << local_path_string << "][size=" << size << "]" << endl;
 
-    return truncate(local_path_string.c_str(),size);
+    cout << "truncate[path=" << local_path_string << "][size=" << size << "]"
+         << endl;
+
+    return truncate(local_path_string.c_str(), size);
 }
 
-static int adb_mknod(const char *path, mode_t mode, dev_t rdev) {
+static int adb_mknod(const char* path, mode_t mode, dev_t rdev)
+{
     string path_string;
     string local_path_string;
     path_string.assign(path);
     local_path_string = tempDirPath;
-    string_replacer(path_string,"/","-");
+    string_replacer(path_string, "/", "-");
     local_path_string.append(path_string);
     path_string.assign(path);
 
     cout << "mknod for " << local_path_string << "\n";
-    mknod(local_path_string.c_str(),mode, rdev);
+    mknod(local_path_string.c_str(), mode, rdev);
 
     shell_escape_path(path_string);
     shell_escape_path(local_path_string);
 
-    adb_push(local_path_string,path_string);
+    adb_push(local_path_string, path_string);
     adb_shell("sync");
 
     invalidateCache(path_string);
@@ -782,13 +836,14 @@ static int adb_mknod(const char *path, mode_t mode, dev_t rdev) {
     return 0;
 }
 
-static int adb_mkdir(const char *path, mode_t mode) {
+static int adb_mkdir(const char* path, mode_t mode)
+{
     string path_string;
     string local_path_string;
     path_string.assign(path);
     fileData[path_string].timestamp = fileData[path_string].timestamp + 50;
-    local_path_string = tempDirPath;
-    string_replacer(path_string,"/","-");
+    local_path_string               = tempDirPath;
+    string_replacer(path_string, "/", "-");
     local_path_string.append(path_string);
     path_string.assign(path);
 
@@ -803,11 +858,11 @@ static int adb_mkdir(const char *path, mode_t mode) {
     return 0;
 }
 
-static int adb_rename(const char *from, const char *to) {
-    string local_from_string,local_to_string = tempDirPath;
+static int adb_rename(const char* from, const char* to)
+{
+    string local_from_string, local_to_string = tempDirPath;
 
     string from_string = string(from), to_string = string(to);
-
 
     local_from_string.append(from);
     local_to_string.append(to);
@@ -818,32 +873,31 @@ static int adb_rename(const char *from, const char *to) {
     shell_escape_path(from_string);
     shell_escape_path(to_string);
 
-
     string command = "mv '";
     command.append(from_string);
     command.append("' '");
     command.append(to_string);
     command.append("'");
-    cout << "Renaming " << from << " to " << to <<"\n";
+    cout << "Renaming " << from << " to " << to << "\n";
     adb_shell(command);
     invalidateCache(string(from));
     invalidateCache(string(to));
     return 0;
 }
 
-static int adb_rmdir(const char *path) {
+static int adb_rmdir(const char* path)
+{
     string path_string;
     string local_path_string;
     path_string.assign(path);
     fileData[path_string].timestamp = fileData[path_string].timestamp + 50;
-    local_path_string = tempDirPath;
-    string_replacer(path_string,"/","-");
+    local_path_string               = tempDirPath;
+    string_replacer(path_string, "/", "-");
     local_path_string.append(path_string);
     path_string.assign(path);
 
     shell_escape_path(path_string);
     shell_escape_path(local_path_string);
-
 
     string command = "rm -r '";
     command.append(path_string);
@@ -851,17 +905,18 @@ static int adb_rmdir(const char *path) {
     adb_shell(command);
     invalidateCache(path_string);
 
-    //rmdir(local_path_string.c_str());
+    // rmdir(local_path_string.c_str());
     return 0;
 }
 
-static int adb_unlink(const char *path) {
+static int adb_unlink(const char* path)
+{
     string path_string;
     string local_path_string;
     path_string.assign(path);
     fileData[path_string].timestamp = fileData[path_string].timestamp + 50;
-    local_path_string = tempDirPath;
-    string_replacer(path_string,"/","-");
+    local_path_string               = tempDirPath;
+    string_replacer(path_string, "/", "-");
     local_path_string.append(path_string);
     path_string.assign(path);
 
@@ -877,7 +932,7 @@ static int adb_unlink(const char *path) {
     return 0;
 }
 
-static int adb_readlink(const char *path, char *buf, size_t size)
+static int adb_readlink(const char* path, char* buf, size_t size)
 {
     string path_string(path);
     shell_escape_path(path_string);
@@ -889,56 +944,66 @@ static int adb_readlink(const char *path, char *buf, size_t size)
     for (num_slashes = ii = 0; ii < strlen(path); ii++)
         if (path[ii] == '/')
             num_slashes++;
-    if (num_slashes >= 1) num_slashes--;
+    if (num_slashes >= 1)
+        num_slashes--;
 
-    if (fileData.find(path_string) ==  fileData.end() 
-	|| fileData[path_string].timestamp + 30 < time(NULL)) {
+    if (fileData.find(path_string) == fileData.end() ||
+        fileData[path_string].timestamp + 30 < time(NULL))
+    {
         string command = "ls -l -a -d '";
         command.append(path_string);
         command.append("'");
         output = adb_shell(command);
-        if (output.empty()) 
-            return -EINVAL; 
+        if (output.empty())
+            return -EINVAL;
         // error format: "/sbin/healthd: Permission denied"
-        if (!output.front().compare(output.front().length() - sizeof(PERMISSION_ERR_MSG) + 1,
-                                    sizeof(PERMISSION_ERR_MSG) - 1, PERMISSION_ERR_MSG))
+        if (!output.front().compare(
+                output.front().length() - sizeof(PERMISSION_ERR_MSG) + 1,
+                sizeof(PERMISSION_ERR_MSG) - 1, PERMISSION_ERR_MSG))
         {
             fileData[path_string].statOutput.erase();
-        } else {
+        }
+        else
+        {
             fileData[path_string].statOutput = output.front();
         }
         fileData[path_string].timestamp = time(NULL);
-    } else{
+    }
+    else
+    {
         cout << "from cache " << path << "\n";
     }
-    string &res = fileData[path_string].statOutput;
-    if (res.empty()) {
+    string& res = fileData[path_string].statOutput;
+    if (res.empty())
+    {
         // file exists, but no info available
         return -EINVAL;
     }
-    if (!is_valid_ls_output(res)) {
-      return -ENOENT;
+    if (!is_valid_ls_output(res))
+    {
+        return -ENOENT;
     }
     cout << "adb_readlink " << res << endl;
     size_t pos = res.find(" -> ");
-    if(pos == string::npos)
-       return -EINVAL;
-    pos+=4;
+    if (pos == string::npos)
+        return -EINVAL;
+    pos += 4;
     size_t my_size = res.size();
-    buf[0] = 0;
-    if (res[pos] == '/') {
-	    while(res[pos] == '/')
-		    ++pos;
-	    my_size += 3 * num_slashes - pos;
-	    if(my_size >= size)
-		    return -ENOSYS;
-	    for (;num_slashes;num_slashes--) {
-		    strncat(buf,"../",size);
-	    }
+    buf[0]         = 0;
+    if (res[pos] == '/')
+    {
+        while (res[pos] == '/') ++pos;
+        my_size += 3 * num_slashes - pos;
+        if (my_size >= size)
+            return -ENOSYS;
+        for (; num_slashes; num_slashes--)
+        {
+            strncat(buf, "../", size);
+        }
     }
-    if(my_size >= size)
-	    return -ENOSYS;
-    strncat(buf, res.c_str() + pos,size);
+    if (my_size >= size)
+        return -ENOSYS;
+    strncat(buf, res.c_str() + pos, size);
     return 0;
 }
 
@@ -953,26 +1018,26 @@ static struct fuse_operations adbfs_oper;
 
    @see fuse_main in fuse.h.
  */
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
-    signal(SIGSEGV, handler);   // install our handler
+    signal(SIGSEGV, handler); // install our handler
     makeTmpDir();
     memset(&adbfs_oper, sizeof(adbfs_oper), 0);
-    adbfs_oper.readdir= adb_readdir;
-    adbfs_oper.getattr= adb_getattr;
-    adbfs_oper.access= adb_access;
-    adbfs_oper.open= adb_open;
-    adbfs_oper.flush = adb_flush;
-    adbfs_oper.release = adb_release;
-    adbfs_oper.read= adb_read;
-    adbfs_oper.write = adb_write;
-    adbfs_oper.utimens = adb_utimens;
+    adbfs_oper.readdir  = adb_readdir;
+    adbfs_oper.getattr  = adb_getattr;
+    adbfs_oper.access   = adb_access;
+    adbfs_oper.open     = adb_open;
+    adbfs_oper.flush    = adb_flush;
+    adbfs_oper.release  = adb_release;
+    adbfs_oper.read     = adb_read;
+    adbfs_oper.write    = adb_write;
+    adbfs_oper.utimens  = adb_utimens;
     adbfs_oper.truncate = adb_truncate;
-    adbfs_oper.mknod = adb_mknod;
-    adbfs_oper.mkdir = adb_mkdir;
-    adbfs_oper.rename = adb_rename;
-    adbfs_oper.rmdir = adb_rmdir;
-    adbfs_oper.unlink = adb_unlink;
+    adbfs_oper.mknod    = adb_mknod;
+    adbfs_oper.mkdir    = adb_mkdir;
+    adbfs_oper.rename   = adb_rename;
+    adbfs_oper.rmdir    = adb_rmdir;
+    adbfs_oper.unlink   = adb_unlink;
     adbfs_oper.readlink = adb_readlink;
     adb_shell("ls");
     return fuse_main(argc, argv, &adbfs_oper, NULL);

--- a/utils.h
+++ b/utils.h
@@ -10,7 +10,7 @@
  *      Redistribution and use in source and binary forms, with or without
  *      modification, are permitted provided that the following conditions are
  *      met:
- *      
+ *
  *      * Redistributions of source code must retain the above copyright
  *        notice, this list of conditions and the following disclaimer.
  *      * Redistributions in binary form must reproduce the above
@@ -20,7 +20,7 @@
  *      * Neither the name of the  nor the names of its
  *        contributors may be used to endorse or promote products derived from
  *        this software without specific prior written permission.
- *      
+ *
  *      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  *      "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  *      LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -33,25 +33,26 @@
  *      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  *      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
- 
-#include <fuse.h>
-#include <stdio.h>
+
 #include <errno.h>
 #include <fcntl.h>
+#include <fuse.h>
+#include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 #include <cstdlib>
 #include <fstream>
+#include <iostream>
+#include <map>
+#include <queue>
 #include <sstream>
 #include <string>
-#include <iostream>
-#include <queue>
 #include <vector>
-#include <map>
-#include <unistd.h>
 
 using namespace std;
 
-struct fileCache{
+struct fileCache
+{
     time_t timestamp;
     string statOutput;
 };
@@ -61,10 +62,12 @@ vector<string> make_array(const string&, const string&);
 
 string& string_replacer(string&, const string&, const string&);
 
-vector<string> make_array(const string& data, const string& delimiters = " "){
+vector<string> make_array(const string& data, const string& delimiters = " ")
+{
     vector<string> result;
-    if (data.size() < 1) return result;
-    //string delimiters = " ";
+    if (data.size() < 1)
+        return result;
+    // string delimiters = " ";
     string::size_type lastPos = data.find_first_not_of(delimiters, 0);
     string::size_type pos     = data.find_first_of(delimiters, lastPos);
     while (string::npos != pos || string::npos != lastPos)
@@ -72,7 +75,7 @@ vector<string> make_array(const string& data, const string& delimiters = " "){
         result.push_back(data.substr(lastPos, pos - lastPos));
         lastPos = data.find_first_not_of(delimiters, pos);
         if (lastPos != string::npos)
-            pos = data.find_first_of(delimiters, lastPos);                
+            pos = data.find_first_of(delimiters, lastPos);
         else
             break;
     }
@@ -90,62 +93,65 @@ vector<string> make_array(const string& data, const string& delimiters = " "){
    @param find the string s2, i.e., the pattern to be replaced.
    @param replace the string s3, i.e., the replacement for s2.
  */
-string& string_replacer(string &source, const string& find, const string& replace) {
-    size_t j = 0;
-    for ( ; (j = source.find(find,j)) != string::npos ; ) {
-	source.replace( j, find.length(), replace );
-        j = j + replace.length();
+string& string_replacer(string& source, const string& find,
+                        const string& replace)
+{
+    for (size_t j = 0; (j = source.find(find, j)) != string::npos;
+         j += replace.length())
+    {
+        source.replace(j, find.length(), replace);
     }
     return source;
 }
 
 int xtoi(const char* xs, unsigned int* result)
 {
- size_t szlen = strlen(xs);
- int i, xv, fact;
+    size_t szlen = strlen(xs);
+    int i, xv, fact;
 
- if (szlen > 0)
- {
-  // Converting more than 32bit hexadecimal value?
-  if (szlen>8) return 2; // exit
-
-  // Begin conversion here
-  *result = 0;
-  fact = 1;
-
-  // Run until no more character to convert
-  for(i=szlen-1; i>=0 ;i--)
-  {
-   if (isxdigit(*(xs+i)))
-   {
-    if (*(xs+i)>=97)
+    if (szlen > 0)
     {
-     xv = ( *(xs+i) - 97) + 10;
-    }
-    else if ( *(xs+i) >= 65)
-    {
-     xv = (*(xs+i) - 65) + 10;
-    }
-    else
-    {
-     xv = *(xs+i) - 48;
-    }
-    *result += (xv * fact);
-    fact *= 16;
-   }
-   else
-   {
-    // Conversion was abnormally terminated
-    // by non hexadecimal digit, hence
-    // returning only the converted with
-    // an error value 4 (illegal hex character)
-    return 4;
-   }
-  }
- }
+        // Converting more than 32bit hexadecimal value?
+        if (szlen > 8)
+            return 2; // exit
 
- // Nothing to convert
- return 1;
+        // Begin conversion here
+        *result = 0;
+        fact    = 1;
+
+        // Run until no more character to convert
+        for (i = szlen - 1; i >= 0; i--)
+        {
+            if (isxdigit(*(xs + i)))
+            {
+                if (*(xs + i) >= 97)
+                {
+                    xv = (*(xs + i) - 97) + 10;
+                }
+                else if (*(xs + i) >= 65)
+                {
+                    xv = (*(xs + i) - 65) + 10;
+                }
+                else
+                {
+                    xv = *(xs + i) - 48;
+                }
+                *result += (xv * fact);
+                fact *= 16;
+            }
+            else
+            {
+                // Conversion was abnormally terminated
+                // by non hexadecimal digit, hence
+                // returning only the converted with
+                // an error value 4 (illegal hex character)
+                return 4;
+            }
+        }
+    }
+
+    // Nothing to convert
+    return 1;
 }
 
 /**
@@ -155,21 +161,21 @@ int xtoi(const char* xs, unsigned int* result)
  */
 queue<string> exec_command(const string& command)
 {
-    cout << "--*-- " << "exec_command: "  << command << "\n";
+    cout << "--*-- "
+         << "exec_command: " << command << "\n";
     queue<string> output;
-    FILE *fp = popen(command.c_str(), "r" );
+    FILE* fp = popen(command.c_str(), "r");
 
     char buff[1000];
     string tmp_string;
-    while ( fgets( buff, sizeof buff, fp ) != NULL && !feof(fp) )
+    while (fgets(buff, sizeof buff, fp) != NULL && !feof(fp))
     {
         tmp_string.assign(buff);
-        tmp_string.erase(tmp_string.size()-2);
+        tmp_string.erase(tmp_string.size() - 2);
         output.push(tmp_string);
     }
 
-    pclose( fp );
+    pclose(fp);
 
     return output;
 }
-


### PR DESCRIPTION
This commit implements a consistent code style, which is defined by the
following clang-format configuration file:

```
BasedOnStyle: Google
AllowShortIfStatementsOnASingleLine: false
AllowShortCaseLabelsOnASingleLine: true
PointerAlignment: Left
DerivePointerAlignment: false
SpacesBeforeTrailingComments: 1
BreakBeforeBraces: Allman
AlignConsecutiveAssignments: true
IndentWidth: 4
```

(If there are any suggestions to change any of the style options, I'm obviously willing to change them)