### PR TITLE
fix swapped memset args, add -Wall compiler flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CXXFLAGS=$(shell pkg-config fuse --cflags)
-LDFLAGS=$(shell pkg-config fuse --libs)
+CXXFLAGS=-Wall $(shell pkg-config fuse --cflags)
+LDFLAGS=-Wall $(shell pkg-config fuse --libs)
 
 TARGET=adbfs
 

--- a/adbfs.cpp
+++ b/adbfs.cpp
@@ -957,7 +957,7 @@ int main(int argc, char *argv[])
 {
     signal(SIGSEGV, handler);   // install our handler
     makeTmpDir();
-    memset(&adbfs_oper, sizeof(adbfs_oper), 0);
+    memset(&adbfs_oper, 0, sizeof(adbfs_oper));
     adbfs_oper.readdir= adb_readdir;
     adbfs_oper.getattr= adb_getattr;
     adbfs_oper.access= adb_access;


### PR DESCRIPTION
Adding `-Wall` compilation flag revealed a simple mistake, the arguments for a `memset` were swapped: 
```
adbfs.cpp: In function ‘int main(int, char**)’:
adbfs.cpp:960:46: warning: ‘memset’ used with constant zero length parameter; this could be due to transposed parameters [-Wmemset-transposed-args]
     memset(&adbfs_oper, sizeof(adbfs_oper), 0);
                                              ^
```
While this should not cause problems (the struct is static, so it's 0 anyway), it still should be corrected :)