### PR TITLE
fix gcc 8 warnings

### DIFF
--- a/adbfs.cpp
+++ b/adbfs.cpp
@@ -919,7 +919,7 @@ static int adb_readlink(const char *path, char *buf, size_t size)
 
     // get the number of slashes in the path
     int num_slashes, ii;
-    for (num_slashes = ii = 0; ii < strlen(path); ii++)
+    for (num_slashes = ii = 0; ii < (int)strlen(path); ii++)
         if (path[ii] == '/')
             num_slashes++;
     if (num_slashes >= 1) num_slashes--;

--- a/utils.h
+++ b/utils.h
@@ -164,8 +164,8 @@ queue<string> exec_command(const string& command)
     while ( fgets( buff, sizeof buff, fp ) != NULL && !feof(fp) )
     {
         tmp_string.assign(buff);
-        while (tmp_string.size() > 0 &&
-               tmp_string[tmp_string.size() - 1] == '\n' ||
+        while ((tmp_string.size() > 0 &&
+               tmp_string[tmp_string.size() - 1] == '\n') ||
                tmp_string[tmp_string.size() - 1] == '\r') {
           tmp_string.erase(tmp_string.size()-1);
         }


### PR DESCRIPTION
Just fixed gcc 8 warnings while running make.
Nothing special here.