### PR TITLE
Fix exec_command's newline cleanup

### DIFF
--- a/utils.h
+++ b/utils.h
@@ -165,8 +165,8 @@ queue<string> exec_command(const string& command)
     {
         tmp_string.assign(buff);
         while (tmp_string.size() > 0 &&
-               tmp_string[tmp_string.size() - 1] == '\n' ||
-               tmp_string[tmp_string.size() - 1] == '\r') {
+               (tmp_string[tmp_string.size() - 1] == '\n' ||
+                tmp_string[tmp_string.size() - 1] == '\r')) {
           tmp_string.erase(tmp_string.size()-1);
         }
         output.push(tmp_string);


### PR DESCRIPTION
The precedence of && is higher than ||, leading to the \r check being
evaluated even on zero-length strings (against string index -1).
Explicitly grouping the \n and \r checks prevents this.