### PR TITLE
feat: add docker testing

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -23,8 +23,8 @@ jobs:
     needs: build
     runs-on: ubuntu-lastest
     container:
-      image: budtmo/docker-android-x86-10.0
-      # options: --privileged
+      image: budtmo/docker-android:emulator_12.0
+      options: --privileged
     steps:
       - uses: actions/checkout@v2
       - name: prepare

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -30,7 +30,8 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: adbfs-bin
-        path: /usr/bin/adbfs
+    - name: copy adbfs binary
+      run: sudo cp ${{ github.workspace }}/adbfs /usr/bin/adbfs
     - name: Enable KVM
       run: |
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -24,7 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [29]
+        api-level: [21, 29, 31, 33, 34, 35]
+
     steps:
     - uses: actions/checkout@v4
     - name: prepare

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: prepare
-        run: apt-get install fuse libfuse-dev
+        run: apt-get update && apt-get install fuse libfuse-dev
       - name: get-adbfs-binary
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -23,11 +23,14 @@ jobs:
           ./adbfs
   test:
     runs-on: ubuntu-18.04
-    container: budtmo/docker-android-x86-10.0
+
+    container:
+      image: budtmo/docker-android-x86-10.0
+      options: --priviledged
     steps:
       - uses: actions/checkout@v2
       - name: prepare
-        run: sudo apt-get install fuse libfuse-dev
+        run: apt-get install fuse libfuse-dev
       - name: Download a single artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -39,7 +39,7 @@ jobs:
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 29
-        script: ./gradlew connectedCheck
+        script: ./docker/run-docker-test.sh
     # services:
       # emulator:
         # image: budtmo/docker-android:emulator_12.0

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -5,11 +5,32 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
-    
+    runs-on: ubuntu-18.04
+
     steps:
     - uses: actions/checkout@v2
     - name: build-deps
       run: sudo apt-get install libfuse-dev
     - name: make
       run: make
+
+    - name: copy-binary
+      uses: actions/upload-artifact@v3
+      with:
+        name: adbfs-bin
+        retention_days: 5
+        path: |
+          ./adbfs
+  test:
+    runs-on: ubuntu-18.04
+    container: budtmo/docker-android-x86-10.0
+    steps:
+      - uses: actions/checkout@v2
+      - name: prepare
+        run: sudo apt-get install fuse libfuse-dev
+      - name: Download a single artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: adbfs-bin
+      - name: run-tests
+        run: ./docker/run-docker-test.sh

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-lastest
     container:
       image: budtmo/docker-android-x86-10.0
-      options: --privileged
+      # options: --privileged
     steps:
       - uses: actions/checkout@v2
       - name: prepare

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [21, 29, 31, 33, 34, 35]
+        api-level: [21, 29, 35]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         api-level: 29
         script: |
-          export PATH=/usr/local/lib/android/sdk/platform-tools:$PATH && sudo ./tests/run.sh
+          sudo bash -c 'env PATH=/usr/local/lib/android/sdk/platform-tools:$PATH ./tests/run.sh'
     # services:
       # emulator:
         # image: budtmo/docker-android:emulator_12.0

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -30,6 +30,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: adbfs-bin
+        path: /usr/bin/adbfs
     - name: Enable KVM
       run: |
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -39,7 +40,7 @@ jobs:
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 29
-        script: ./docker/run-docker-test.sh
+        script: sudo ./docker/run-docker-test.sh
     # services:
       # emulator:
         # image: budtmo/docker-android:emulator_12.0

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -23,6 +23,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         api-level: [21, 29, 31, 33, 34, 35]
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -21,7 +21,7 @@ jobs:
           ./adbfs
   test:
     needs: build
-    runs-on: ubuntu-18.04
+    runs-on: macos-latest
     container:
       image: budtmo/docker-android-x86-10.0
       options: --privileged

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [21, 29, 35]
+        api-level: [29]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -44,8 +44,7 @@ jobs:
       with:
         api-level: 29
         script: |
-          export PATH=/usr/local/lib/android/sdk/platform-tools:$PATH
-          sudo ./tests/run.sh
+          export PATH=/usr/local/lib/android/sdk/platform-tools:$PATH && sudo ./tests/run.sh
     # services:
       # emulator:
         # image: budtmo/docker-android:emulator_12.0

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -21,7 +21,7 @@ jobs:
           ./adbfs
   test:
     needs: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-lastest
     container:
       image: budtmo/docker-android-x86-10.0
       options: --privileged

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -26,12 +26,12 @@ jobs:
 
     container:
       image: budtmo/docker-android-x86-10.0
-      options: --priviledged
+      options: --privileged
     steps:
       - uses: actions/checkout@v2
       - name: prepare
         run: apt-get install fuse libfuse-dev
-      - name: Download a single artifact
+      - name: get-adbfs-binary
         uses: actions/download-artifact@v3
         with:
           name: adbfs-bin

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -6,14 +6,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: build-deps
       run: sudo apt-get -y install libfuse-dev
     - name: make
       run: make
 
     - name: copy-binary
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: adbfs-bin
         retention-days: 5
@@ -22,15 +22,16 @@ jobs:
   test:
     needs: build
     runs-on: ubuntu-latest
-    container:
-      image: budtmo/docker-android:emulator_12.0
-      options: --privileged
+    services:
+      emulator:
+        image: budtmo/docker-android:emulator_12.0
+        options: --privileged
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: prepare
         run: apt-get update && apt-get install -y fuse libfuse-dev
       - name: get-adbfs-binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: adbfs-bin
       - name: run-tests

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -4,9 +4,7 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-18.04
-
     steps:
     - uses: actions/checkout@v2
     - name: build-deps

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -22,8 +22,8 @@ jobs:
         path: |
           ./adbfs
   test:
+    needs: build
     runs-on: ubuntu-18.04
-
     container:
       image: budtmo/docker-android-x86-10.0
       options: --privileged

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -43,7 +43,9 @@ jobs:
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 29
-        script: sudo ./docker/run-docker-test.sh
+        script: |
+          export PATH=/usr/local/lib/android/sdk/platform-tools:$PATH
+          sudo ./tests/run.sh
     # services:
       # emulator:
         # image: budtmo/docker-android:emulator_12.0

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -35,4 +35,4 @@ jobs:
         with:
           name: adbfs-bin
       - name: run-tests
-        run: ./docker/run-docker-test.sh
+        run: sudo bash ./docker/run-docker-test.sh

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
         sudo udevadm control --reload-rules
-        sudo udevadm trigger --name-match=kv
+        sudo udevadm trigger --name-match=kvm
     - name: run tests
       uses: reactivecircus/android-emulator-runner@v2
       with:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -31,7 +31,9 @@ jobs:
       with:
         name: adbfs-bin
     - name: copy adbfs binary
-      run: sudo cp ${{ github.workspace }}/adbfs /usr/bin/adbfs
+      run: |
+        sudo cp ${{ github.workspace }}/adbfs /usr/bin/adbfs
+        sudo chmod +x /usr/bin/adbfs
     - name: Enable KVM
       run: |
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: prepare
-        run: apt-get update && apt-get install -y fuse libfuse-dev
+        run: sudo apt-get update && sudo apt-get install -y fuse libfuse-dev
       - name: get-adbfs-binary
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: build-deps
-      run: sudo apt-get install libfuse-dev
+      run: sudo apt-get -y install libfuse-dev
     - name: make
       run: make
 
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: prepare
-        run: apt-get update && apt-get install fuse libfuse-dev
+        run: apt-get update && apt-get install -y fuse libfuse-dev
       - name: get-adbfs-binary
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: build-deps

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -22,17 +22,27 @@ jobs:
   test:
     needs: build
     runs-on: ubuntu-latest
-    services:
-      emulator:
-        image: budtmo/docker-android:emulator_12.0
-        options: --privileged
     steps:
-      - uses: actions/checkout@v4
-      - name: prepare
-        run: sudo apt-get update && sudo apt-get install -y fuse libfuse-dev
-      - name: get-adbfs-binary
-        uses: actions/download-artifact@v4
-        with:
-          name: adbfs-bin
-      - name: run-tests
-        run: sudo bash ./docker/run-docker-test.sh
+    - uses: actions/checkout@v4
+    - name: prepare
+      run: sudo apt-get update && sudo apt-get install -y fuse libfuse-dev
+    - name: get-adbfs-binary
+      uses: actions/download-artifact@v4
+      with:
+        name: adbfs-bin
+    - name: Enable KVM
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kv
+    - name: run tests
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 29
+        script: ./gradlew connectedCheck
+    # services:
+      # emulator:
+        # image: budtmo/docker-android:emulator_12.0
+        # options: --privileged
+      # - name: run-tests
+      #   run: sudo bash ./docker/run-docker-test.sh

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -21,7 +21,7 @@ jobs:
           ./adbfs
   test:
     needs: build
-    runs-on: ubuntu-lastest
+    runs-on: ubuntu-latest
     container:
       image: budtmo/docker-android:emulator_12.0
       options: --privileged

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -22,6 +22,9 @@ jobs:
   test:
     needs: build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        api-level: [29]
     steps:
     - uses: actions/checkout@v4
     - name: prepare
@@ -39,15 +42,32 @@ jobs:
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
+
+    - name: AVD cache
+      uses: actions/cache@v4
+      id: avd-cache
+      with:
+        path: |
+          ~/.android/avd/*
+          ~/.android/adb*
+        key: avd-${{ matrix.api-level }}
+
+    - name: create AVD and generate snapshot for caching
+      if: steps.avd-cache.outputs.cache-hit != 'true'
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: ${{ matrix.api-level }}
+        force-avd-creation: false
+        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: false
+        script: echo "Generated AVD snapshot for caching."
+
+
     - name: run tests
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 29
-        script: |
-          sudo bash -c 'env PATH=/usr/local/lib/android/sdk/platform-tools:$PATH ./tests/run.sh'
-    # services:
-      # emulator:
-        # image: budtmo/docker-android:emulator_12.0
-        # options: --privileged
-      # - name: run-tests
-      #   run: sudo bash ./docker/run-docker-test.sh
+        api-level: ${{ matrix.api-level }}
+        force-avd-creation: false
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: true
+        script: sudo env PATH=/usr/local/lib/android/sdk/platform-tools:$PATH ./tests/run.sh

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -16,12 +16,12 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: adbfs-bin
-        retention_days: 5
+        retention-days: 5
         path: |
           ./adbfs
   test:
     needs: build
-    runs-on: macos-latest
+    runs-on: ubuntu-18.04
     container:
       image: budtmo/docker-android-x86-10.0
       options: --privileged

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 as buildenv
+FROM ubuntu:latest as buildenv
 RUN apt update
 RUN apt install -y build-essential git pkg-config
 RUN apt install -y libfuse-dev fuse
@@ -7,25 +7,22 @@ WORKDIR /src
 RUN make
 
 
-FROM budtmo/docker-android-x86-10.0
-RUN apt update
+FROM us-docker.pkg.dev/android-emulator-268719/images/30-google-x64:30.1.2
+# FROM docker.io/budtmo/docker-android:emulator_12.0
+# RUN apt update
 
-RUN apt install -y fuse libfuse-dev
+# RUN apt install -y fuse libfuse-dev
 
-ADD ./* /src/
+# ADD ./* /src/
+ADD ./tests/* /src/tests/
 ADD ./docker/* /src/docker/
 
-RUN chmod +x /src/docker/run-docker-test.sh
+RUN chmod +x /src/docker/*.sh
 
 COPY --from=buildenv /src/adbfs /usr/bin/adbfs
 RUN chmod +x /usr/bin/adbfs
 
 WORKDIR /src
-CMD /src/docker/run-docker-test.sh
-
-
-
-
-
-
-
+# CMD /src/docker/run-docker-test.sh
+ENTRYPOINT [ "sudo", "bash", "/src/docker/run-test.sh" ]
+# ENTRYPOINT [ "bash" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN chmod +x /src/docker/run-docker-test.sh
 COPY --from=buildenv /src/adbfs /usr/bin/adbfs
 RUN chmod +x /usr/bin/adbfs
 
-WORKDIR /root
+WORKDIR /src
 CMD /src/docker/run-docker-test.sh
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,32 +1,28 @@
-# FROM ubuntu:22.04 as buildenv
-# RUN apt install -y build-essential git pkg-config
-# RUN apt install -y libfuse-dev fuse
-# ADD ./* /src/
-# WORKDIR /src
-# RUN make
+FROM ubuntu:18.04 as buildenv
+RUN apt update
+RUN apt install -y build-essential git pkg-config
+RUN apt install -y libfuse-dev fuse
+ADD ./* /src/
+WORKDIR /src
+RUN make
 
 
 FROM budtmo/docker-android-x86-10.0
 RUN apt update
-
-RUN apt install -y build-essential git pkg-config
 
 RUN apt install -y fuse libfuse-dev
 
 ADD ./* /src/
 ADD ./docker/* /src/docker/
 
-WORKDIR /src
-RUN make
-
 RUN chmod +x /src/docker/run-docker-test.sh
+
+COPY --from=buildenv /src/adbfs /usr/bin/adbfs
+RUN chmod +x /usr/bin/adbfs
 
 WORKDIR /root
 CMD /src/docker/run-docker-test.sh
 
-
-# COPY --from=buildenv /src/adbfs /usr/bin/adbfs
-# RUN chmod +x /usr/bin/adbfs
 
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,30 @@
+# FROM ubuntu:22.04 as buildenv
+# RUN apt install -y build-essential git pkg-config
+# RUN apt install -y libfuse-dev fuse
+# ADD ./* /src/
+# WORKDIR /src
+# RUN make
+
+
+
+FROM budtmo/docker-android-x86-10.0
+RUN apt update
+
+RUN apt install -y build-essential git pkg-config
+
+RUN apt install -y fuse libfuse-dev
+
+ADD ./* /src/
+WORKDIR /src
+RUN make
+
+
+
+# COPY --from=buildenv /src/adbfs /usr/bin/adbfs
+# RUN chmod +x /usr/bin/adbfs
+
+
+
+
+
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,6 @@
 # RUN make
 
 
-
 FROM budtmo/docker-android-x86-10.0
 RUN apt update
 
@@ -21,6 +20,8 @@ WORKDIR /src
 RUN make
 
 RUN chmod +x /src/docker/run-docker-test.sh
+
+WORKDIR /root
 CMD /src/docker/run-docker-test.sh
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,9 +15,13 @@ RUN apt install -y build-essential git pkg-config
 RUN apt install -y fuse libfuse-dev
 
 ADD ./* /src/
+ADD ./docker/* /src/docker/
+
 WORKDIR /src
 RUN make
 
+RUN chmod +x /src/docker/run-docker-test.sh
+CMD /src/docker/run-docker-test.sh
 
 
 # COPY --from=buildenv /src/adbfs /usr/bin/adbfs

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -9,11 +9,11 @@ echo Running supervisord in the background
 popd || exit
 
 
-
+WAIT_TIME=120
 
 wait_available() {
 
-  RETRIES=60
+  RETRIES=$WAIT_TIME
   WAIT_DIR="$1"
 
   while [ $RETRIES -gt 0 ];
@@ -32,7 +32,7 @@ wait_available() {
 
   if [ $RETRIES -le 0 ]
   then
-    echo "Emulator directory $1 was not available, exiting"
+    echo "Emulator directory $1 was not available for $WAIT_TIME seconds, exiting"
     exit 1
   fi
 

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -47,7 +47,7 @@ wait_available() {
 }
 
 echo Checking readiness via adb shell ls -d /sdcard/Android
-wait_available /sdcard/Android
+wait_available /sdcard
 
 
 mkdir -p /adbfs

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -39,7 +39,7 @@ echo Checking readiness via adb shell ls -d /sdcard/Android
 wait_available /sdcard/Android
 
 mkdir -p /adbfs
-./adbfs /adbfs
+/usr/bin/adbfs /adbfs
 
 echo Ready to run adbfs tests
 
@@ -47,10 +47,71 @@ BASE_DIR=/adbfs/sdcard/test
 
 test_mkdir() {
 
-  mkdir "$BASE_DIR/x"
-  output=$(ls -lad "$BASE_DIR/x")
-  # TODO: verify output is correct
+  local_timestamp=$(date "+%s")
 
+  mkdir "$BASE_DIR/x"
+  output=$(ls -lad --time-style="+%s" "$BASE_DIR/x")
+
+  timestamp=$(echo $output | cut -d' ' -f 6)
+  path=$(echo $output | cut -d' ' -f 7)
+
+  timestamp_diff=$((local_timestamp - timestamp))
+  abs_diff=${timestamp_diff#-}
+
+  if [ "$abs_diff" -gt 120 ];
+  then
+    echo "FAIL test_mkdir: file timestamp difference exceeds 120s: $abs_diff"
+    exit 1
+  fi
+
+  if [ "$path" != "$BASE_DIR/x" ];
+  then
+    echo "FAIL test_mkdir: unexpected path"
+    exit 1
+  fi
+
+  echo "PASS test_mkdir"
+}
+
+
+test_catfile() {
+
+  local_timestamp=$(date "+%s")
+
+  desired_content="Hello world"
+
+  echo "$desired_content" > "$BASE_DIR/file.txt"
+
+  output=$(ls -lad --time-style="+%s" "$BASE_DIR/file.txt")
+
+  timestamp=$(echo $output | cut -d' ' -f 6)
+  path=$(echo $output | cut -d' ' -f 7)
+
+  timestamp_diff=$((local_timestamp - timestamp))
+  abs_diff=${timestamp_diff#-}
+
+  if [ "$abs_diff" -gt 120 ];
+  then
+    echo "FAIL test_catfile: file timestamp difference exceeds 120s: $abs_diff"
+    exit 1
+  fi
+
+  if [ "$path" != "$BASE_DIR/file.txt" ];
+  then
+    echo "FAIL test_catfile: unexpected path"
+    exit 1
+  fi
+
+  file_contents=$(cat $BASE_DIR/file.txt)
+
+  if [ "$file_contents" != "Hello world" ]
+  then
+    echo "FAIL test_catfile: unexpected content: $file_contents"
+    echo "Expected: $desired_content"
+    exit 1
+  fi
+
+  echo "PASS test_catfile"
 }
 
 
@@ -58,16 +119,13 @@ test_mkdir() {
 mkdir "$BASE_DIR"
 
 test_mkdir
+test_catfile
 
+# todo
 
+# copy file with cp -a (archive, preserve timestamps)
 
-
-# todo, test mkdir
-
-# create file with cat
-
-# copy file
-
+# read a directory
 
 # touch to update time
 
@@ -75,4 +133,8 @@ test_mkdir
 
 rm -rf "$BASE_DIR"
 
+
+
+# rsync, both directions (compared against rsync of the very same tree on a "pure local" FS).
+# ompared to adb push --sync as well maybe
 

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -15,12 +15,18 @@ then
   popd || exit
 fi
 
-sleep 1
-
-ps aux | grep supervisord
-
-
 WAIT_TIME=60
+
+sleep 3;
+tail -f /var/log/supervisor/docker-android.stderr.log &
+
+
+echo HOME = "$HOME"
+echo ANDROID_AVD_HOME = "$ANDROID_AVD_HOME"
+echo ANDROID_SDK_HOME = "$ANDROID_SDK_HOME"
+
+echo "ls $HOME/.android/avd"
+ls $HOME/.android/avd
 
 wait_available() {
 

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -20,7 +20,7 @@ wait_available() {
   do
     RETRIES=$((RETRIES - 1))
 
-    OUTPUT=$(adb shell ls -d "$WAIT_DIR")
+    OUTPUT=$(adb shell ls -d "$WAIT_DIR" 2> /dev/null)
 
     if [ "$OUTPUT" == "$WAIT_DIR" ]
     then
@@ -34,6 +34,14 @@ wait_available() {
   then
     echo "Emulator directory $1 was not available for $WAIT_TIME seconds, exiting"
     echo "Last output was: $OUTPUT"
+    echo ""
+    echo "Logs for docker-appium were (stdout)"
+    echo ""
+    cat /var/log/supervisor/docker-android.stdout.log
+    echo ""
+    echo "stderr"
+    echo ""
+    cat /var/log/supervisor/docker-android.stderr.log
     exit 1
   fi
 

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -33,6 +33,7 @@ wait_available() {
   if [ $RETRIES -le 0 ]
   then
     echo "Emulator directory $1 was not available for $WAIT_TIME seconds, exiting"
+    echo "Last output was: $OUTPUT"
     exit 1
   fi
 

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -9,6 +9,7 @@
 
 WAIT_TIME=60
 
+export PATH=/usr/local/lib/android/sdk/platform-tools:$PATH
 
 wait_available() {
 

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
 
-
-
-
-pushd /root || exit
-
-echo Running supervisord in the background
+# echo Running supervisord in the background
 # cd /root || exit
-HOME=/root /usr/bin/supervisord --configuration supervisord.conf &
 
-popd || exit
+# SUPERVISORD_CONFIG_PATH="${APP_PATH}/mixins/configs/process"
+# /usr/bin/supervisord --configuration ${SUPERVISORD_CONFIG_PATH}/supervisord-port.conf & \
+# /usr/bin/supervisord --configuration ${SUPERVISORD_CONFIG_PATH}/supervisord-base.conf & \
 
 WAIT_TIME=60
 
@@ -38,13 +34,13 @@ wait_available() {
     echo "Emulator directory $1 was not available for $WAIT_TIME seconds, exiting"
     echo "Last output was: $OUTPUT"
     echo ""
-    echo "Logs for docker-appium were (stdout)"
-    echo ""
-    cat /var/log/supervisor/docker-android.stdout.log
-    echo ""
-    echo "stderr"
-    echo ""
-    cat /var/log/supervisor/docker-android.stderr.log
+    # echo "Logs for docker-appium were (stdout)"
+    # echo ""
+    # cat /var/log/supervisor/docker-android.stdout.log
+    # echo ""
+    # echo "stderr"
+    # echo ""
+    # cat /var/log/supervisor/docker-android.stderr.log
     exit 1
   fi
 

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
+pushd /root || exit
+
 echo Running supervisord in the background
 # cd /root || exit
 /usr/bin/supervisord --configuration supervisord.conf &
 
-cd /src || exit
+popd || exit
+
 
 
 

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -15,7 +15,10 @@ then
   popd || exit
 fi
 
+sleep 1
+
 ps aux | grep supervisord
+
 
 WAIT_TIME=60
 
@@ -57,6 +60,7 @@ wait_available() {
 
 echo Checking readiness via adb shell ls -d /sdcard/Android
 wait_available /sdcard/Android
+
 
 mkdir -p /adbfs
 /usr/bin/adbfs /adbfs

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -2,31 +2,17 @@
 
 
 
-if [ -z "$GITHUB_ACTIONS_NOTNEEDED" ];
-then
-  echo "Running outside of github actions so we need to run the emulator start script"
 
-  pushd /root || exit
+pushd /root || exit
 
-  echo Running supervisord in the background
-  # cd /root || exit
-  /usr/bin/supervisord --configuration supervisord.conf &
+echo Running supervisord in the background
+# cd /root || exit
+HOME=/root /usr/bin/supervisord --configuration supervisord.conf &
 
-  popd || exit
-fi
+popd || exit
 
 WAIT_TIME=60
 
-sleep 3;
-tail -f /var/log/supervisor/docker-android.stderr.log &
-
-
-echo HOME = "$HOME"
-echo ANDROID_AVD_HOME = "$ANDROID_AVD_HOME"
-echo ANDROID_SDK_HOME = "$ANDROID_SDK_HOME"
-
-echo "ls $HOME/.android/avd"
-ls $HOME/.android/avd
 
 wait_available() {
 

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -9,7 +9,7 @@ echo Running supervisord in the background
 popd || exit
 
 
-WAIT_TIME=120
+WAIT_TIME=160
 
 wait_available() {
 
@@ -20,7 +20,7 @@ wait_available() {
   do
     RETRIES=$((RETRIES - 1))
 
-    OUTPUT=$(adb shell ls -d "$WAIT_DIR" 2> /dev/null)
+    OUTPUT=$(adb shell ls -d "$WAIT_DIR")
 
     if [ "$OUTPUT" == "$WAIT_DIR" ]
     then

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 
-if [ -z "$GITHUB_ACTIONS" ];
+
+if [ -z "$GITHUB_ACTIONS_NOTNEEDED" ];
 then
   echo "Running outside of github actions so we need to run the emulator start script"
 
@@ -13,6 +14,8 @@ then
 
   popd || exit
 fi
+
+ps aux | grep supervisord
 
 WAIT_TIME=60
 

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -47,7 +47,8 @@ wait_available() {
 }
 
 echo Checking readiness via adb shell ls -d /sdcard/Android
-wait_available /sdcard
+adb devices
+wait_available /
 
 
 mkdir -p /adbfs

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 
-pushd /root || exit
 
-echo Running supervisord in the background
-# cd /root || exit
-/usr/bin/supervisord --configuration supervisord.conf &
+if [ -z "$GITHUB_ACTIONS" ];
+then
+  echo "Running outside of github actions so we need to run the emulator start script"
 
-popd || exit
+  pushd /root || exit
 
+  echo Running supervisord in the background
+  # cd /root || exit
+  /usr/bin/supervisord --configuration supervisord.conf &
 
-WAIT_TIME=160
+  popd || exit
+fi
+
+WAIT_TIME=60
 
 wait_available() {
 

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -1,22 +1,39 @@
 #!/bin/bash
 
 echo Running supervisord in the background
+# cd /root || exit
 /usr/bin/supervisord --configuration supervisord.conf &
+
+cd /src || exit
 
 
 echo Checking readiness via adb shell ls -d /
 
-RETRIES=30
+RETRIES=60
 
 while [ $RETRIES -gt 0 ];
 do
-  echo hi $RETRIES
   RETRIES=$((RETRIES - 1))
 
   OUTPUT=$(adb shell ls -d /)
 
-  echo "Output $OUTPUT"
-  echo "adb devices"
-  adb devices
-  sleep 3
+  if [ "$OUTPUT" == "/" ]
+  then
+    break;
+  fi
+  sleep 1
+  # adb connect 127.0.0.1:5555
 done
+
+if [ $RETRIES -le 0 ]
+then
+  echo "Could not connect to emulator, exiting"
+  exit 1
+fi
+
+echo Ready to run adbfs
+
+mkdir -p /adbfs
+./adbfs /adbfs
+
+ls -la /adbfs

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+echo Running supervisord in the background
+/usr/bin/supervisord --configuration supervisord.conf &
+
+
+echo Checking readiness via adb shell ls -d /
+
+RETRIES=30
+
+while [ $RETRIES -gt 0 ];
+do
+  echo hi $RETRIES
+  RETRIES=$((RETRIES - 1))
+
+  OUTPUT=$(adb shell ls -d /)
+
+  echo "Output $OUTPUT"
+  echo "adb devices"
+  adb devices
+  sleep 3
+done

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -7,33 +7,72 @@ echo Running supervisord in the background
 cd /src || exit
 
 
-echo Checking readiness via adb shell ls -d /
 
-RETRIES=60
+wait_available() {
 
-while [ $RETRIES -gt 0 ];
-do
-  RETRIES=$((RETRIES - 1))
+  RETRIES=60
+  WAIT_DIR="$1"
 
-  OUTPUT=$(adb shell ls -d /)
+  while [ $RETRIES -gt 0 ];
+  do
+    RETRIES=$((RETRIES - 1))
 
-  if [ "$OUTPUT" == "/" ]
+    OUTPUT=$(adb shell ls -d "$WAIT_DIR" 2> /dev/null)
+
+    if [ "$OUTPUT" == "$WAIT_DIR" ]
+    then
+      break;
+    fi
+    sleep 1
+
+  done
+
+  if [ $RETRIES -le 0 ]
   then
-    break;
+    echo "Emulator directory $1 was not available, exiting"
+    exit 1
   fi
-  sleep 1
-  # adb connect 127.0.0.1:5555
-done
 
-if [ $RETRIES -le 0 ]
-then
-  echo "Could not connect to emulator, exiting"
-  exit 1
-fi
+}
 
-echo Ready to run adbfs
+echo Checking readiness via adb shell ls -d /sdcard/Android
+wait_available /sdcard/Android
 
 mkdir -p /adbfs
 ./adbfs /adbfs
 
-ls -la /adbfs
+echo Ready to run adbfs tests
+
+BASE_DIR=/adbfs/sdcard/test
+
+test_mkdir() {
+
+  mkdir "$BASE_DIR/x"
+  output=$(ls -lad "$BASE_DIR/x")
+  # TODO: verify output is correct
+
+}
+
+
+
+mkdir "$BASE_DIR"
+
+test_mkdir
+
+
+
+
+# todo, test mkdir
+
+# create file with cat
+
+# copy file
+
+
+# touch to update time
+
+# copy preserving timestamps
+
+rm -rf "$BASE_DIR"
+
+

--- a/docker/run-test.sh
+++ b/docker/run-test.sh
@@ -1,0 +1,12 @@
+
+export SCRIPT_PATH="docker-android"
+export WORK_PATH="/home/androidusr"
+export APP_PATH=${WORK_PATH}/${SCRIPT_PATH}
+export LOG_PATH=${WORK_PATH}/logs
+export SUPERVISORD_CONFIG_PATH="${APP_PATH}/mixins/configs/process"
+export DEVICE_TYPE=emulator
+
+/usr/bin/supervisord --configuration ${SUPERVISORD_CONFIG_PATH}/supervisord-port.conf & \
+/usr/bin/supervisord --configuration ${SUPERVISORD_CONFIG_PATH}/supervisord-base.conf & \
+
+bash $(dirname $0)/../tests/run.sh

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -9,7 +9,6 @@
 
 WAIT_TIME=60
 
-export PATH=/usr/local/lib/android/sdk/platform-tools:$PATH
 
 wait_available() {
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -52,7 +52,7 @@ wait_available /
 
 
 mkdir -p /adbfs
-/usr/bin/adbfs /adbfs
+adbfs /adbfs
 
 echo Ready to run adbfs tests
 


### PR DESCRIPTION
This PR adds a scaffold for automated tests based on docker and an android emulator. The neat thing about this approach is that we can also use multiple versions of android, and while that may not be fully exhaustive in terms of the devices out there, its way better than having nothing.

Without tests, changes to this project are quite high risk. With tests, I think we can get things going :smile: 

Currently covers only a single Android version, but its easy to add a second dockerfile.

To try it out

```
docker build -t adbfs-rootless-v1 -f docker/Dockerfile .
docker run --privileged --rm adbfs-rootless-v1
```

The reason `--privileged` is needed is because the android emulators need virtualization support (/dev/kvm needs to be available). I'm still hoping we'll be able to run these in GitHub actions but I've not tried yet.

This is WIP. Would be great to have some ideas about good representative tests to run and ways to verify that everything is ok.