### PR TITLE
Emulator test matrix in "Feat/add docker testing"

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -21,6 +21,41 @@ jobs:
           ./adbfs
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        emulator:
+          - { 'api_level': 35, 'api_type_target': 'google_apis', 'arch': 'x86_64' }
+          - { 'api_level': 34, 'api_type_target': 'default', 'arch': 'x86_64' }
+          - { 'api_level': 33, 'api_type_target': 'aosp_atd', 'arch': 'x86_64' }
+          - { 'api_level': 32, 'api_type_target': 'aosp_atd', 'arch': 'x86_64' }
+          - { 'api_level': 31, 'api_type_target': 'aosp_atd', 'arch': 'x86_64' }
+          - { 'api_level': 30, 'api_type_target': 'aosp_atd', 'arch': 'x86_64' }
+          - { 'api_level': 30, 'api_type_target': 'aosp_atd', 'arch': 'x86' }
+          - { 'api_level': 29, 'api_type_target': 'default', 'arch': 'x86_64' }
+          - { 'api_level': 29, 'api_type_target': 'default', 'arch': 'x86' }
+          - { 'api_level': 28, 'api_type_target': 'default', 'arch': 'x86_64' }
+          - { 'api_level': 28, 'api_type_target': 'default', 'arch': 'x86' }
+          - { 'api_level': 27, 'api_type_target': 'default', 'arch': 'x86_64' }
+          - { 'api_level': 27, 'api_type_target': 'default', 'arch': 'x86' }
+          - { 'api_level': 26, 'api_type_target': 'default', 'arch': 'x86_64' }
+          - { 'api_level': 26, 'api_type_target': 'default', 'arch': 'x86' }
+          - { 'api_level': 25, 'api_type_target': 'default', 'arch': 'x86_64' }
+          - { 'api_level': 25, 'api_type_target': 'default', 'arch': 'x86' }
+          - { 'api_level': 24, 'api_type_target': 'default', 'arch': 'x86_64' }
+          - { 'api_level': 24, 'api_type_target': 'default', 'arch': 'x86' }
+          - { 'api_level': 23, 'api_type_target': 'default', 'arch': 'x86_64' }
+          - { 'api_level': 23, 'api_type_target': 'default', 'arch': 'x86' }
+          - { 'api_level': 22, 'api_type_target': 'default', 'arch': 'x86_64' }
+          - { 'api_level': 22, 'api_type_target': 'default', 'arch': 'x86' }
+          - { 'api_level': 21, 'api_type_target': 'default', 'arch': 'x86_64' }
+          - { 'api_level': 21, 'api_type_target': 'default', 'arch': 'x86' }
+
+          - { 'api_level': 19, 'api_type_target': 'default', 'arch': 'x86' }
+          - { 'api_level': 18, 'api_type_target': 'default', 'arch': 'x86' }
+          - { 'api_level': 17, 'api_type_target': 'default', 'arch': 'x86' }
+          - { 'api_level': 16, 'api_type_target': 'default', 'arch': 'x86' }
+          - { 'api_level': 15, 'api_type_target': 'default', 'arch': 'x86' }
     steps:
     - uses: actions/checkout@v4
     - name: prepare
@@ -41,7 +76,9 @@ jobs:
     - name: run tests
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 29
+        api-level: ${{ matrix.emulator.api_level }}
+        arch: ${{ matrix.emulator.arch }}
+        target: ${{ matrix.emulator.api_type_target }}
         script: sudo ./docker/run-docker-test.sh
     # services:
       # emulator:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -20,16 +20,15 @@ jobs:
         path: |
           ./adbfs
   test:
-    needs: build
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: prepare
       run: sudo apt-get update && sudo apt-get install -y fuse libfuse-dev
-    - name: get-adbfs-binary
-      uses: actions/download-artifact@v4
-      with:
-        name: adbfs-bin
+
+    - name: make
+      run: make
+
     - name: copy adbfs binary
       run: |
         sudo cp ${{ github.workspace }}/adbfs /usr/bin/adbfs

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -49,9 +49,11 @@ wait_available() {
 
 # No need to check for readiness when running on GHA
 # reactivecircus/android-emulator-runner already handles that
-#echo Checking readiness via adb shell ls -d /sdcard/Android
-#adb devices
-#wait_available /
+# Disabling wait_available because it errors out sometims
+#
+# echo Checking readiness via adb shell ls -d /sdcard/Android
+# adb devices
+# wait_available /
 
 
 mkdir -p /adbfs
@@ -60,6 +62,8 @@ mkdir -p /adbfs
 echo Ready to run adbfs tests
 
 BASE_DIR=/adbfs/sdcard/test
+
+adb shell ls -lh /sdcard
 
 test_mkdir() {
 

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -47,9 +47,11 @@ wait_available() {
 
 }
 
-echo Checking readiness via adb shell ls -d /sdcard/Android
-adb devices
-wait_available /
+# No need to check for readiness when running on GHA
+# reactivecircus/android-emulator-runner already handles that
+#echo Checking readiness via adb shell ls -d /sdcard/Android
+#adb devices
+#wait_available /
 
 
 mkdir -p /adbfs

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -63,7 +63,7 @@ echo Ready to run adbfs tests
 
 BASE_DIR=/adbfs/sdcard/test
 
-adb shell ls -lh /sdcard
+adb shell ls -l /sdcard
 
 test_mkdir() {
 
@@ -81,7 +81,8 @@ test_mkdir() {
   if [ "$abs_diff" -gt 120 ];
   then
     echo "FAIL test_mkdir: file timestamp difference exceeds 120s: $abs_diff"
-    exit 1
+    echo "timestamp: $timestamp"
+    echo "local timestamp: $local_timestamp"
   fi
 
   if [ "$path" != "$BASE_DIR/x" ];
@@ -113,7 +114,8 @@ test_catfile() {
   if [ "$abs_diff" -gt 120 ];
   then
     echo "FAIL test_catfile: file timestamp difference exceeds 120s: $abs_diff"
-    exit 1
+    echo "timestamp: $timestamp"
+    echo "local timestamp: $local_timestamp"
   fi
 
   if [ "$path" != "$BASE_DIR/file.txt" ];

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -47,9 +47,6 @@ wait_available() {
 
 }
 
-# No need to check for readiness when running on GHA
-# reactivecircus/android-emulator-runner already handles that
-# Disable wait_available because it errors out sometimes
 echo Checking readiness via adb shell ls -d /sdcard/Android
 adb devices
 wait_available /

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -49,11 +49,10 @@ wait_available() {
 
 # No need to check for readiness when running on GHA
 # reactivecircus/android-emulator-runner already handles that
-# Disabling wait_available because it errors out sometims
-#
-# echo Checking readiness via adb shell ls -d /sdcard/Android
-# adb devices
-# wait_available /
+# Disable wait_available because it errors out sometimes
+echo Checking readiness via adb shell ls -d /sdcard/Android
+adb devices
+wait_available /
 
 
 mkdir -p /adbfs
@@ -83,6 +82,7 @@ test_mkdir() {
     echo "FAIL test_mkdir: file timestamp difference exceeds 120s: $abs_diff"
     echo "timestamp: $timestamp"
     echo "local timestamp: $local_timestamp"
+    exit 1
   fi
 
   if [ "$path" != "$BASE_DIR/x" ];
@@ -116,6 +116,7 @@ test_catfile() {
     echo "FAIL test_catfile: file timestamp difference exceeds 120s: $abs_diff"
     echo "timestamp: $timestamp"
     echo "local timestamp: $local_timestamp"
+    exit 1
   fi
 
   if [ "$path" != "$BASE_DIR/file.txt" ];

--- a/docker/run-docker-test.sh
+++ b/docker/run-docker-test.sh
@@ -63,7 +63,7 @@ echo Ready to run adbfs tests
 
 BASE_DIR=/adbfs/sdcard/test
 
-adb shell ls -l /sdcard
+adb shell ls -l /sdcard/
 
 test_mkdir() {
 


### PR DESCRIPTION
Hey,

I've added some emulators, but mind you that the whole test framework is flaky.

/sdcard may or may not be a good place for test file creation. I would do that in /data/local/tmp, but that also may not be available on all devices.

Ubuntu only has a single fuse version, so we can't add that to the test matrix. There's fuse3, but we would need support in adbfs before we test it.

Haven't looked into testing arm64 on macos yet.
