### PR TITLE
fix: signed/unsigned integer comparison warning

### DIFF
--- a/adbfs.cpp
+++ b/adbfs.cpp
@@ -962,7 +962,7 @@ static int adb_readlink(const char *path, char *buf, size_t size)
     queue<string> output;
 
     // get the number of slashes in the path
-    int num_slashes, ii;
+    size_t num_slashes, ii;
     for (num_slashes = ii = 0; ii < strlen(path); ii++)
         if (path[ii] == '/')
             num_slashes++;


### PR DESCRIPTION
Minor g++ compiler warning fix. 

Thanks for the handy project.

Best,
Chris



Closes #66

