### PR TITLE
Implements utimens touch dates

### DIFF
--- a/adbfs.cpp
+++ b/adbfs.cpp
@@ -803,24 +803,25 @@ static int adb_utimens(const char *path, const struct timespec ts[2]) {
 
     if (!set_atime && !set_mtime)
         return 0;
+    string command = "";
     if (set_atime) {
-        string command = "touch -a -d ";
+        command.append("touch -a -d ");
         command.append(format_gnu_touch_time(atime));
         command.append(" '");
         command.append(path_string);
         command.append("'");
-        cout << command<<"\n";
-        adb_shell(command);
+        if (set_mtime)
+            command.append(" && ");
     }
     if (set_mtime) {
-        string command = "touch -m -d ";
+        command.append("touch -m -d ");
         command.append(format_gnu_touch_time(atime));
         command.append(" '");
         command.append(path_string);
         command.append("'");
-        cout << command<<"\n";
-        adb_shell(command);
     }
+    cout << command<<"\n";
+    adb_shell(command);
 
     // If we forgot to mount -o rescan then we can remount and touch to trigger the scan.
     if (adbfs_conf.rescan) adb_rescan_file(path_string);

--- a/adbfs.cpp
+++ b/adbfs.cpp
@@ -835,7 +835,7 @@ static int adb_utimens(const char *path, const struct timespec ts[2]) {
             output.pop();
         }
         bool date_failed = front.length() > sizeof(TOUCH_TOYBOX_GNU_DATE_ERR_MSG)
-                && front.compare(0, sizeof(TOUCH_TOYBOX_GNU_DATE_ERR_MSG) - 1, TOUCH_TOYBOX_GNU_DATE_ERR_MSG);
+                && !front.compare(0, sizeof(TOUCH_TOYBOX_GNU_DATE_ERR_MSG) - 1, TOUCH_TOYBOX_GNU_DATE_ERR_MSG);
         date_failed = date_failed || (front.length() > sizeof(TOUCH_BUSYBOX_GNU_DATE_ERR_MSG)
                 && front.compare(0, sizeof(TOUCH_BUSYBOX_GNU_DATE_ERR_MSG) - 1, TOUCH_BUSYBOX_GNU_DATE_ERR_MSG));
 

--- a/adbfs.cpp
+++ b/adbfs.cpp
@@ -837,7 +837,7 @@ static int adb_utimens(const char *path, const struct timespec ts[2]) {
         bool date_failed = front.length() > sizeof(TOUCH_TOYBOX_GNU_DATE_ERR_MSG)
                 && !front.compare(0, sizeof(TOUCH_TOYBOX_GNU_DATE_ERR_MSG) - 1, TOUCH_TOYBOX_GNU_DATE_ERR_MSG);
         date_failed = date_failed || (front.length() > sizeof(TOUCH_BUSYBOX_GNU_DATE_ERR_MSG)
-                && front.compare(0, sizeof(TOUCH_BUSYBOX_GNU_DATE_ERR_MSG) - 1, TOUCH_BUSYBOX_GNU_DATE_ERR_MSG));
+                && !front.compare(0, sizeof(TOUCH_BUSYBOX_GNU_DATE_ERR_MSG) - 1, TOUCH_BUSYBOX_GNU_DATE_ERR_MSG));
 
         if (date_failed) {
             if (!touch_gnu_mode)

--- a/adbfs.cpp
+++ b/adbfs.cpp
@@ -820,7 +820,7 @@ static int adb_utimens(const char *path, const struct timespec ts[2]) {
     }
     if (set_mtime) {
         command.append("touch -m -d ");
-        command.append(format_touch_time(atime, touch_gnu_mode));
+        command.append(format_touch_time(mtime, touch_gnu_mode));
         command.append(" '");
         command.append(path_string);
         command.append("'");

--- a/utils.h
+++ b/utils.h
@@ -180,17 +180,30 @@ queue<string> exec_command(const string& command)
 }
 
 /**
-   Convert timespec to GNU touch parameter format
-   https://www.gnu.org/software/coreutils/manual/html_node/General-date-syntax.html
-   Toybox's touch used on Android supports the GNU extension for the nanoseconds : "@%s.%N"
+   Convert timespec to touch parameter format
 
-   @param timespec the time to be converted
+   gnu_format allows to specify up to nanoseconds.
+   https://www.gnu.org/software/coreutils/manual/html_node/General-date-syntax.html
+   Toybox's touch used on Android supports the GNU extension for the nanoseconds since 0.8.1 : "@%s.%N"
+   Toybox was begin used instead of Busybox in Android 6
+
+   @param t the time to be converted
+   @param gnu_format if touch supports GNU time format
  */
-static string format_gnu_touch_time(const struct timespec& t) {
-    ostringstream ss;
-    ss << "@"
-       << t.tv_sec
-       << "."
-       << setw(9) << setfill('0') << t.tv_nsec;
-    return ss.str();
+static string format_touch_time(const struct timespec& t, bool gnu_format) {
+    if (gnu_format) {
+        ostringstream ss;
+        ss << "@"
+            << t.tv_sec
+            << "."
+            << setw(9) << setfill('0') << t.tv_nsec;
+            return ss.str();
+    } else {
+        char timebuf[32];
+        struct tm _tm;
+        localtime_r(&(t.tv_sec), &_tm);
+        strftime(timebuf, sizeof(timebuf), "%Y-%m-%dT%H:%M:%S", &_tm);
+        string out = timebuf;
+        return out;
+    }
 }

--- a/utils.h
+++ b/utils.h
@@ -48,6 +48,8 @@
 #include <vector>
 #include <map>
 #include <unistd.h>
+#include <ctime>
+#include <iomanip>
 
 using namespace std;
 
@@ -177,3 +179,18 @@ queue<string> exec_command(const string& command)
     return output;
 }
 
+/**
+   Convert timespec to GNU touch parameter format
+   https://www.gnu.org/software/coreutils/manual/html_node/General-date-syntax.html
+   Toybox's touch used on Android supports the GNU extension for the nanoseconds : "@%s.%N"
+
+   @param timespec the time to be converted
+ */
+static string format_gnu_touch_time(const struct timespec& t) {
+    ostringstream ss;
+    ss << "@"
+       << t.tv_sec
+       << "."
+       << setw(9) << setfill('0') << t.tv_nsec;
+    return ss.str();
+}

--- a/utils.h
+++ b/utils.h
@@ -185,25 +185,25 @@ queue<string> exec_command(const string& command)
    gnu_format allows to specify up to nanoseconds.
    https://www.gnu.org/software/coreutils/manual/html_node/General-date-syntax.html
    Toybox's touch used on Android supports the GNU extension for the nanoseconds since 0.8.1 : "@%s.%N"
-   Toybox was begin used instead of Busybox in Android 6
+   Toybox was begin used instead of Busybox in Android 6.
 
    @param t the time to be converted
    @param gnu_format if touch supports GNU time format
  */
 static string format_touch_time(const struct timespec& t, bool gnu_format) {
+    ostringstream ss;
     if (gnu_format) {
-        ostringstream ss;
         ss << "@"
             << t.tv_sec
             << "."
             << setw(9) << setfill('0') << t.tv_nsec;
-            return ss.str();
+        return ss.str();
     } else {
-        char timebuf[32];
-        struct tm _tm;
-        localtime_r(&(t.tv_sec), &_tm);
-        strftime(timebuf, sizeof(timebuf), "%Y-%m-%dT%H:%M:%S", &_tm);
-        string out = timebuf;
-        return out;
+        // It could be possible to convert here the timezone instead of creating a more complex shell comamand.
+        ss << "`date -ud "
+            << "@" << t.tv_sec  << "."
+            << setw(9) << setfill('0') << t.tv_nsec
+            << " +%Y-%m-%dT%H:%M:%S`";
     }
+    return ss.str();
 }


### PR DESCRIPTION
Hello,
Here is a PR that implements the rest of utimens instead of just doing a touch.
It handles :
- POSIX time with nanoseconds if Android supports it
- Automatic fallback for old version (old toybox (tested) or even busybox (not tested < Android 6))
- Handling of timezone (may not be perfect)
- atime/mtime separately
- UTIME_OMIT/UTIME_NOW values

Tested on :
- Oneplus 9 (Android 14)
- LG G6 (Android 9, testing the fallback method)

I also fixed adb_truncate output that outputted to fuse the shell escaped path instead of the normal one. I needed that to test fully the new features. If you want I can separate this fix in another PR.

The fallback method could be improved later by getting the Android system timezone locally and converting the timezone instead of using `date -ud`. Doesn't seems to slow down a lot and it may complexify the code. 