### PR TITLE
Add full stat capabilities, fixed utimens and managing old or exotic Android OSes

### DIFF
--- a/adbfs.cpp
+++ b/adbfs.cpp
@@ -803,24 +803,25 @@ static int adb_utimens(const char *path, const struct timespec ts[2]) {
 
     if (!set_atime && !set_mtime)
         return 0;
+    string command = "";
     if (set_atime) {
-        string command = "touch -a -d ";
+        command.append("touch -a -d ");
         command.append(format_gnu_touch_time(atime));
         command.append(" '");
         command.append(path_string);
         command.append("'");
-        cout << command<<"\n";
-        adb_shell(command);
+        if (set_mtime)
+            command.append(" && ");
     }
     if (set_mtime) {
-        string command = "touch -m -d ";
+        command.append("touch -m -d ");
         command.append(format_gnu_touch_time(atime));
         command.append(" '");
         command.append(path_string);
         command.append("'");
-        cout << command<<"\n";
-        adb_shell(command);
     }
+    cout << command<<"\n";
+    adb_shell(command);
 
     // If we forgot to mount -o rescan then we can remount and touch to trigger the scan.
     if (adbfs_conf.rescan) adb_rescan_file(path_string);

--- a/adbfs.cpp
+++ b/adbfs.cpp
@@ -835,7 +835,7 @@ static int adb_utimens(const char *path, const struct timespec ts[2]) {
             output.pop();
         }
         bool date_failed = front.length() > sizeof(TOUCH_TOYBOX_GNU_DATE_ERR_MSG)
-                && front.compare(0, sizeof(TOUCH_TOYBOX_GNU_DATE_ERR_MSG) - 1, TOUCH_TOYBOX_GNU_DATE_ERR_MSG);
+                && !front.compare(0, sizeof(TOUCH_TOYBOX_GNU_DATE_ERR_MSG) - 1, TOUCH_TOYBOX_GNU_DATE_ERR_MSG);
         date_failed = date_failed || (front.length() > sizeof(TOUCH_BUSYBOX_GNU_DATE_ERR_MSG)
                 && front.compare(0, sizeof(TOUCH_BUSYBOX_GNU_DATE_ERR_MSG) - 1, TOUCH_BUSYBOX_GNU_DATE_ERR_MSG));
 

--- a/adbfs.cpp
+++ b/adbfs.cpp
@@ -837,7 +837,7 @@ static int adb_utimens(const char *path, const struct timespec ts[2]) {
         bool date_failed = front.length() > sizeof(TOUCH_TOYBOX_GNU_DATE_ERR_MSG)
                 && !front.compare(0, sizeof(TOUCH_TOYBOX_GNU_DATE_ERR_MSG) - 1, TOUCH_TOYBOX_GNU_DATE_ERR_MSG);
         date_failed = date_failed || (front.length() > sizeof(TOUCH_BUSYBOX_GNU_DATE_ERR_MSG)
-                && front.compare(0, sizeof(TOUCH_BUSYBOX_GNU_DATE_ERR_MSG) - 1, TOUCH_BUSYBOX_GNU_DATE_ERR_MSG));
+                && !front.compare(0, sizeof(TOUCH_BUSYBOX_GNU_DATE_ERR_MSG) - 1, TOUCH_BUSYBOX_GNU_DATE_ERR_MSG));
 
         if (date_failed) {
             if (!touch_gnu_mode)

--- a/adbfs.cpp
+++ b/adbfs.cpp
@@ -820,7 +820,7 @@ static int adb_utimens(const char *path, const struct timespec ts[2]) {
     }
     if (set_mtime) {
         command.append("touch -m -d ");
-        command.append(format_touch_time(atime, touch_gnu_mode));
+        command.append(format_touch_time(mtime, touch_gnu_mode));
         command.append(" '");
         command.append(path_string);
         command.append("'");

--- a/adbfs.cpp
+++ b/adbfs.cpp
@@ -74,6 +74,7 @@
 #define FUSE_USE_VERSION 26
 #include "utils.h"
 #include <unistd.h>
+#include <algorithm>
 
 #include<stddef.h>
 #include <execinfo.h>
@@ -110,6 +111,27 @@ static const char PERMISSION_ERR_MSG[] = ": Permission denied";
 static const char TOUCH_TOYBOX_GNU_DATE_ERR_MSG[] = "touch: bad '@";
 static const char TOUCH_BUSYBOX_GNU_DATE_ERR_MSG[] = "touch: invalid date '@";
 
+static char local_tz[64] = "\0";
+
+// GLOBALS determined by initAndroidInfos. Go see the function for more details
+// The local Android timezone
+static string android_tz = "GMT";
+// If the Android cannot handle utimens
+static bool disable_utimens = false;
+// if coreutils (date/touch) are busybox based
+static bool coreutils_have_stat;
+// if coreutils (date/touch) are busybox based
+static coreutils_type coreutils_touch;
+// if we handle tz convertion to utc instead of coreutils (date/touch)
+static bool computer_tz_convert = true;
+// if we handle tz convertion to local instead of coreutils (date/touch)
+static bool computer_tz_convert_local = false;
+// if touch supports the GNU extension "@epoch.nanosecs"
+static bool touch_gnu_mode = true;
+// If we add the nanoseconds at the end of dates
+static bool touch_nanoseconds = true;
+// The coreutils to force to be used for "touch"
+static string forced_coreutils_touch = "";
 
 
 string tempDirPath;
@@ -123,7 +145,6 @@ void invalidateCache(const string& path) {
 
 map<int,bool> filePendingWrite;
 map<string,bool> fileTruncated;
-bool touch_gnu_mode = true;
 
 /**
    Custom options
@@ -139,6 +160,9 @@ static struct fuse_opt adb_opts[] = {
 };
 
 static struct adb_config adbfs_conf;
+
+#define NO_RECENT_CACHE(FILE) ( fileData.find(FILE) ==  fileData.end() \
+    || fileData[FILE].timestamp + 30 < time(NULL) )
 
 /**
    Return the result of executing the given command string, using
@@ -254,6 +278,478 @@ void makeTmpDir(void) {
     tempDirPath.append("/");
     atexit(&cleanupTmpDir);
 }
+
+
+
+/**
+   Convert time_t to the local time given the foreign tz_value
+
+   Based on https://stackoverflow.com/a/71970632 CC BY-SA 4.0 :
+   Jonathan Leffler who implemented Ikegami answer
+
+   @param t0 the time to be converted
+   @param gnu_format the timezone of the input
+ */
+static struct tm *time_convert_to_local(time_t t0, char const *tz_value) {
+    if (strcmp(tz_value, "GMT") == 0)
+        return gmtime(&t0);
+
+    if(local_tz[0] == 0) {
+        char old_tz[64] = "-none-";
+        char *tz = getenv("TZ");
+        if (tz != 0)
+            strcpy(old_tz, tz);
+    }
+
+    setenv("TZ", tz_value, 1);
+    tzset();
+
+    struct tm *lt = localtime(&t0);
+
+    if (strcmp(local_tz, "-none-") == 0)
+        unsetenv("TZ");
+    else
+        setenv("TZ", local_tz, 1);
+    tzset();
+
+    return lt;
+}
+
+/**
+   Convert timespec to touch parameter format
+
+   gnu_format allows to specify the posix epoch directly in touch.
+https://www.gnu.org/software/coreutils/manual/html_node/General-date-syntax.html
+   Toybox's touch used on Android supports the GNU extension for the
+    nanoseconds since 0.8.1 : "@%s.%N" (automatic try)
+   Toybox was begin used instead of Toolbox in Android 6.
+
+   @param t the time to be converted
+   @param local_time if we pass to touch a UTC "Z" format
+ */
+static string format_touch_time(
+        const struct timespec& t,
+        bool local_time = false) {
+    ostringstream ss;
+    if (coreutils_touch == TOOLBOX_OLD) {
+        ss << "-t " << t.tv_sec << '.' << setw(9) << setfill('0') << t.tv_nsec;
+        return ss.str();
+    }
+    if (coreutils_touch == TOOLBOX) {
+        char buffer[16]; // 20260101.120101\0
+        struct tm *lt = gmtime(&(t.tv_sec));
+        strftime(buffer, sizeof(buffer), "%Y%m%d.%H%M%S", lt);
+        ss << "-t " << buffer;
+        return ss.str();
+    }
+
+    ss << "-d ";
+    if (coreutils_touch == BUSYBOX) {
+        char buffer[16]; // 200001010000.00\0
+        struct tm *lt = time_convert_to_local(t.tv_sec, android_tz.c_str());
+        strftime(buffer, sizeof(buffer), "%Y%m%d%H%M.%S", lt);
+        ss << buffer;
+        return ss.str();
+    }
+
+    if (touch_gnu_mode) {
+        ss << "@" << t.tv_sec;
+    } else if (computer_tz_convert) {
+        char buffer[20]; // 2000-01-01 00:00:00\0
+        struct tm *lt;
+        if (local_time || computer_tz_convert_local)
+            lt = time_convert_to_local(t.tv_sec, android_tz.c_str());
+        else
+            lt = gmtime(&(t.tv_sec));
+        strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%S", lt);
+        ss << buffer;
+    } else {
+        if (local_time)
+            ss << "`date -d ";
+        else
+            ss << "`date -ud ";
+        ss << "@" << t.tv_sec
+           << " +%Y-%m-%dT%H:%M:%S`";
+    }
+    if (touch_nanoseconds)
+        ss << '.' << setw(9) << setfill('0') << t.tv_nsec;
+    if (!touch_gnu_mode && (!local_time || (computer_tz_convert && computer_tz_convert_local)))
+        ss << "Z";
+    return ss.str();
+}
+
+/**
+   Convert a string from stat or ls to a time_t struct
+
+   @param date string describing the date : 2026-05-08
+   @param time string describing the time : 01:16:12.123456781
+   @param time_zone string describing the time zone :
+        +0200 (optional can be '' to be treated as local time)
+ */
+static time_t convert_str_to_date(string date, string time, string time_zone) {
+    time_t res;
+
+    vector<string> ymd = make_array(date, "-");
+    vector<string> hm = make_array(time, ":");
+
+    struct tm ftime_l;
+    ftime_l.tm_year = atoi(ymd[0].c_str()) - 1900;
+    ftime_l.tm_mon  = atoi(ymd[1].c_str()) - 1;
+    ftime_l.tm_mday = atoi(ymd[2].c_str());
+    ftime_l.tm_hour = atoi(hm[0].c_str());
+    ftime_l.tm_min  = atoi(hm[1].c_str());
+    if (hm.size() >= 3) {
+        // if we have the seconds or the simple format
+        // (available in 'ls -ll' but not in 'ls -l')
+        vector<string> sm = make_array(time, ".");
+        ftime_l.tm_sec  = atoi(sm[0].c_str());
+        // nanoseconds can be in the sm[1] value if supported.
+        // However time_t cannot have nanoseconds precision
+        // so we don't care here.
+    }
+    else
+        ftime_l.tm_sec = 0;
+    ftime_l.tm_isdst = -1;
+    res = timegm(&ftime_l);
+
+    const char *android_zone = android_tz.c_str();
+    if (! (time_zone.empty()))
+        android_zone = time_zone.c_str();
+    if (strcmp(android_zone, "GMT") == 0)
+        return res;
+    struct tm *ftime = time_convert_to_local(res, android_zone);
+    res = timegm(ftime);
+    return res;
+}
+
+void printCoreUtilsName(
+        coreutils_type core_type,
+        bool toolbox_version_unkown,
+        bool busybox_touch_no_date,
+        bool busybox_version_unkown,
+        bool toybox_touch_bugged) {
+    switch (core_type) {
+    case TOOLBOX_OLD:
+        cout << "TOOLBOX_OLD"; break;
+    case TOOLBOX:
+        if (toolbox_version_unkown)
+            cout << "TOOLBOX (unknown version)";
+        else
+            cout << "TOOLBOX";
+        break;
+    case BUSYBOX:
+        if (busybox_touch_no_date)
+            cout << "BUSYBOX (<1.15.0)";
+        else if (busybox_version_unkown)
+            cout << "BUSYBOX (<1.15.0)";
+        else
+            cout << "BUSYBOX (unknown version)";
+        break;
+    case TOYBOX:
+        if (toybox_touch_bugged)
+            cout << "TOYBOX (<0.7.2)";
+        else
+            cout << "TOYBOX (>=0.7.2)";
+        break;
+    default: //UNKOWN
+        cout << "unknown"; break;
+    }
+}
+
+
+void initAndroidInfos() {
+    cout << "initAndroidInfos" << endl;
+
+    queue<string> output = adb_shell("date +%Z", false);
+    if (output.size() == 1 && ! output.front().empty()) {
+        android_tz = output.front();
+        cout << "Android time zone is : " << android_tz << endl;
+    } else {
+        computer_tz_convert_local = false;
+        std::cerr << "Cannot determine Android time zone. 'date +%Z' "
+            << "gave a unxexpected answer :" << endl;
+        while (! output.empty()) {
+            std::cerr << output.front().c_str() << endl;
+            output.pop();
+        }
+    }
+
+    bool coreutils_is_old = false;
+
+    /*
+    Should be true after Android 6 (Marshmallow) with toybox introduction
+    Even if another non-default coreutils could have 'stat', it would be
+    unexpected to have a coreutils installed without the 'stat' link present.
+    */
+    output = adb_shell("stat / 2> /dev/null", false);
+    coreutils_have_stat = output.size() != 0 && (! output.front().empty());
+    if (! coreutils_have_stat) {
+        std::cerr << "'stat' command don't exist. Cannot have precise "
+            << "information on files latter." << endl;
+        coreutils_is_old = true;
+    }
+
+    // Begining with the introduction of Torybox in Android 6 (Marshmallow)
+    // Toolbox is always kept but stripped from its interesting commands.
+    output = adb_shell("toolbox 2> /dev/null", false);
+    bool have_toolbox = output.size() != 0 && output.front() == "Toolbox!";
+    bool toolbox_have_touch = true;
+    bool toolbox_is_old;
+    bool toolbox_version_unkown = false;
+    if (have_toolbox) {
+        output = adb_shell("toolbox touch 2> /dev/null", false);
+        if (output.size() != 0 && output.front() == "touch: no such tool")
+            toolbox_have_touch = false;
+    }
+
+    output = adb_shell("toybox --version 2> /dev/null", false);
+    bool have_toybox = output.size() != 0;
+    bool toybox_touch_bugged = false;
+    if (have_toybox) {
+        // "c96e42498c99-android" or 0.7.0-f9a7ae754c27-android
+        string toybox_version_str = output.front();
+        vector<string> toybox_version = make_array(toybox_version_str, ".");
+        // if version does not have a 0.0.0 format (beta version)
+        // or is below 0.7.2
+        if (toybox_version.size() < 3 ||
+            (atoi(toybox_version[0].c_str()) == 0 &&
+                (atoi(toybox_version[1].c_str()) < 7
+                || (atoi(toybox_version[1].c_str()) == 7
+                    && atoi(toybox_version[2].c_str()) < 2)))
+        ) {
+            /*
+            There is a bug in Toybox < 0.7.2 where in touch localtime_r is
+            called with a uninitialized tv_sec. So randomly localtime_r returns
+            a EOVERFLOW (Value too large for defined data type).
+            Touch blame the input, but it is a bug.
+            This was fixed in :
+            https://codeberg.org/landley/toybox/commit/9f3d8aa80fa4d7216106610b077b6d6e4e6dbed4
+            Example :
+            $ touch -ad 2024-02-02T03:02:03 myfile
+            touch: bad '2024-02-02T03:02:03': Value too large for defined data type
+
+            Toybox was introduced in Android 6 (Marshmallow) and have this bug
+            until Android 8.0 (Oreo) The first version fixed in Android is
+            toybox 0.7.3-05146348f7d3-android
+            */
+            toybox_touch_bugged = true;
+        }
+    }
+
+    output = adb_shell("busybox 2> /dev/null", false);
+    bool have_busybox = output.size() != 0
+        && output.front().rfind("BusyBox", 0) == 0;
+    bool busybox_touch_no_date = false;
+    bool busybox_version_unkown = false;
+    if (have_busybox) {
+        // BusyBox v1.31.1-meefik (2019-11-09 21:37:43 MSK) multi-call binary.
+        string busybox_version_str;
+        vector<string> busybox_version = make_array(output.front());
+        if (busybox_version.size() < 2) {
+            busybox_version_str = "0.0.0";
+            busybox_version_unkown = true;
+        } else {
+            busybox_version_str = busybox_version[1];
+        }
+        busybox_version = make_array(busybox_version_str, ".");
+        if (! (busybox_version.size() >= 2 && (
+            atoi(busybox_version[0].c_str()) > 1
+            || (atoi(busybox_version[0].c_str()) == 1
+                && atoi(busybox_version[1].c_str()) >= 15)))
+        ) {
+            // https://busybox.net/oldnews.html
+            // "touch: implement -t TIME"
+            busybox_touch_no_date = true;
+        }
+    }
+
+    // we checked which coreutils is used for touch
+    output = adb_shell("touch --help 2> /dev/null", false);
+    bool touch_help_empty = output.size() == 0 || output.front().empty();
+    if (! touch_help_empty && output.front().rfind("BusyBox", 0) == 0) {
+        coreutils_touch = BUSYBOX;
+    } else if (touch_help_empty && have_toolbox) {
+        output = adb_shell("touch --help", true);
+        // Checking for toolbox
+        if (output.size() == 0 || output.front().rfind("touch: usage:", 0) != 0)
+            coreutils_touch = UNKOWN;
+        else if (output.front().find("[-t time_t]") != string::npos) {
+            // touch: usage: touch [-alm] [-t time_t] <file>
+            toolbox_is_old = true;
+            coreutils_touch = TOOLBOX_OLD;
+        } else if (output.front().find("[-t YYYYMMDD[.hhmmss]]")
+                != string::npos) {
+            // touch: usage: touch [-alm] [-t YYYYMMDD[.hhmmss]] <file>
+            coreutils_touch = TOOLBOX;
+        } else {
+            toolbox_version_unkown = true;
+                coreutils_touch = UNKOWN;
+        }
+    } else if (touch_help_empty)
+        coreutils_touch = UNKOWN;
+    else
+        /*
+            Else we also suppose its TOYBOX. We have no reason to suppose
+            it is otherwise. It is the more POSIX compliant version so even
+            if it is not TOYBOX it should work in most cases.
+        */
+        coreutils_touch = TOYBOX;
+
+    if (coreutils_touch == UNKOWN)
+        std::cerr << "Error: 'touch' is not giving any help page. And it is "
+            << "not toolbox/busybox/toybox. Hoping for the best by supposing "
+            << "it is posix compliant version" << endl;
+
+    cout << "Coreutils found : ";
+    if (have_toolbox) {
+        if (toolbox_is_old)
+            printCoreUtilsName(
+                TOOLBOX_OLD,
+                toolbox_version_unkown,
+                busybox_touch_no_date,
+                busybox_version_unkown,
+                toybox_touch_bugged);
+        else
+            printCoreUtilsName(
+                TOOLBOX,
+                toolbox_version_unkown,
+                busybox_touch_no_date,
+                busybox_version_unkown,
+                toybox_touch_bugged);
+        if (have_busybox || have_toybox)
+            cout << " ";
+    }
+    if (have_toybox) {
+        printCoreUtilsName(
+            TOYBOX,
+            toolbox_version_unkown,
+            busybox_touch_no_date,
+            busybox_version_unkown,
+            toybox_touch_bugged);
+        if (have_busybox)
+            cout << " ";
+    }
+    if (have_busybox) {
+        printCoreUtilsName(
+            BUSYBOX,
+            toolbox_version_unkown,
+            busybox_touch_no_date,
+            busybox_version_unkown,
+            toybox_touch_bugged);
+    }
+    cout << endl;
+
+    cout << "Default coreutils was identified as : ";
+    printCoreUtilsName(
+        coreutils_touch,
+        toolbox_version_unkown,
+        busybox_touch_no_date,
+        busybox_version_unkown,
+        toybox_touch_bugged);
+    cout << endl;
+
+
+    /* Order of priority for touch :
+        - TOYBOX (>=0.7.2)   => New + epoch set (via gnu extension)
+        - TOOLBOX_OLD        => epoch set but old tools
+        - TOOLBOX            => works but have to be carefull with timzones
+        - BUSYBOX (>=1.15.0) => works but no -a but only -m option
+        - UNKOWN             => don't know what will happens
+        - BUSYBOX (unknown)  => don't know what will happens and no -a option
+        - TOYBOX (<0.7.2)    => bugged (almost never works)
+        - BUSYBOX (<1.15.0)  => no touch with date
+        - TOOLBOX-notouch    => no touch
+    */
+    bool coreutils_overwrite = true;
+    if (coreutils_touch != TOYBOX && have_toybox && ! toybox_touch_bugged) {
+        // TOYBOX (>=0.7.2)
+        coreutils_touch = TOYBOX;
+        forced_coreutils_touch = "toybox ";
+    } else if (coreutils_touch != TOOLBOX_OLD && coreutils_touch != TOOLBOX
+            && have_toolbox && toolbox_have_touch && ! toolbox_version_unkown) {
+        // TOOLBOX_OLD / TOOLBOX
+        forced_coreutils_touch = "toolbox ";
+        if (toolbox_is_old)
+            coreutils_touch = TOOLBOX_OLD;
+        else
+            coreutils_touch = TOOLBOX_OLD;
+    } else if (coreutils_touch != TOOLBOX_OLD && coreutils_touch != TOOLBOX
+            && have_busybox && ! busybox_version_unkown
+                && ! busybox_touch_no_date) {
+        // BUSYBOX (>=1.15.0) / BUSYBOX (unknown)
+        coreutils_touch = BUSYBOX;
+        forced_coreutils_touch = "busybox ";
+    } else if (coreutils_touch != TOYBOX && have_toybox) {
+        // TOYBOX (<0.7.2)
+        coreutils_touch = TOYBOX;
+        forced_coreutils_touch = "toybox ";
+    } else if ((coreutils_touch == BUSYBOX && busybox_touch_no_date)
+            || (coreutils_touch == TOOLBOX && ! toolbox_have_touch)) {
+        // BUSYBOX (<1.15.0)/TOOLBOX-notouch
+        std::cerr << "Didn't find a working 'touch' command. Desactivating "
+            << "feature (utimens)..." << endl;
+        disable_utimens = true;
+    } else
+        coreutils_overwrite = false;
+
+    if (coreutils_overwrite) {
+        cout << "Found a better alternative coreutils to use touch : ";
+        printCoreUtilsName(
+            coreutils_touch,
+            toolbox_version_unkown,
+            busybox_touch_no_date,
+            busybox_version_unkown,
+            toybox_touch_bugged);
+        cout << endl;
+    } else
+        cout << "Using default coreutils for 'touch'." << endl;
+
+    switch (coreutils_touch) {
+    case TOOLBOX_OLD:
+        coreutils_is_old = true; break;
+    case TOOLBOX:
+        if (toolbox_version_unkown)
+            std::cerr << "Cannot determine Toolbox version." << endl;
+        else if (! toolbox_have_touch) {
+            std::cerr << "Toolbox don't have a working 'touch' command."
+                << endl;
+            disable_utimens = true;
+        }
+        break;
+    case BUSYBOX:
+        if (busybox_touch_no_date)
+            std::cerr << "Busybox is too old (< 1.15.0) to manage time file "
+                << "chanches (touch -d does not exists). Desactivating feature "
+                << "(utimens)..." << endl;
+        else if (busybox_version_unkown)
+            std::cerr << "Busybox was found as the best coreutils but cannot "
+                << "determine BusyBox version." << endl;
+        break;
+    case TOYBOX:
+        if (toybox_touch_bugged)
+            std::cerr << "Toybox is too old (< 0.7.2) to manage time file "
+                << "chanches (touch -d is bugged). Be prepare to not be able "
+                << "not change file change/modification times." << endl;
+        break;
+    default: //UNKOWN
+        std::cerr << "Can't detect which coreutils to use. Using the default "
+            << "one which is unknown. Hoping for posix compliant commands..."
+            << endl;
+        break;
+    }
+
+    if (coreutils_is_old)
+        std::cerr << "You are probably using a old Android version. "
+        << "Not all operations are guarantee." << endl;
+
+    touch_gnu_mode = ! (
+        coreutils_touch == BUSYBOX
+        || coreutils_touch == TOOLBOX_OLD
+        || coreutils_touch == TOOLBOX);
+    touch_gnu_mode = touch_gnu_mode
+        && ! (coreutils_touch == TOYBOX && toybox_touch_bugged);
+}
+
 
 /**
    Set a given string to an adb push or pull command with given paths.
@@ -413,6 +909,57 @@ bool is_valid_ls_output(const string& file) {
   return true;
 }
 
+/**
+   Populate the stat file cache by calling 'stat'
+
+   @param path_string The path to the file to update
+ */
+static void cache_stat(string path_string) {
+    /*
+        %D = Device ID (hex) (st_dev)
+        %i = inode (ino_t)
+        %f = All mode bits (hex) (mode_t)
+        %h = number of ahrd links (st_nlink)
+        %u = User ID (uid_t)
+        %g = Group ID (gid_t)
+        %t = dev type (dev_t)
+        %s = size (st_size)
+        %b = Size/512 (st_blocks)
+        %B = Bytes per %b (512) (st_blksize)
+        %X = Access unix time (st_atim)
+        %Y = Mod unix time (st_mtim)
+        %Z = Creation unix time (st_ctim)
+        Nanoseconds could be accessed through %x/%y/%z and by using
+            convert_str_to_date adapted to nanoseconds.
+        However the output strut, stat, don't support nanoseconds.
+        caching stat '/system/usr' =
+            fd1c 25194110 a1a4 0 0 0 7 8 512 1761534769 1761534769 1761534769
+    */
+    if (! coreutils_have_stat) {
+        fileData[path_string].noStat = false;
+        fileData[path_string].statOutput.erase();
+        return;
+    }
+
+    string command = "stat -c '%D %i %f %h %u %g %t %s %b %B %X %Y %Z' '";
+    command.append(path_string);
+    command.append("'");
+    queue<string> output = adb_shell(command, true);
+    cout << "caching stat '" << path_string;
+    if (output.empty() || output.front().empty()) {
+        cout << "' (failed) = ";
+        fileData[path_string].statOutput.erase();
+    } else {
+        cout << "' = ";
+        fileData[path_string].statOutput = output.front();
+    }
+    fileData[path_string].noStat = false;
+    if (output.empty())
+        cout << endl;
+    else
+        cout << output.front() <<  endl;
+}
+
 static int adb_getattr(const char *path, struct stat *stbuf)
 {
     cout << "adb_getattr" << endl;
@@ -427,30 +974,41 @@ static int adb_getattr(const char *path, struct stat *stbuf)
     // TODO /caching?
     //
     vector<string> output_chunk;
-    if (fileData.find(path_string) ==  fileData.end()
-	|| fileData[path_string].timestamp + 30 < time(NULL)) {
-        string command = "ls -l -a -d '";
+    if (NO_RECENT_CACHE(path_string)) {
+        // In old Android versions -ll is treated as -l. We handle that later.
+        string command = "ls -llad '";
         command.append(path_string);
         command.append("'");
         output = adb_shell(command, true);
         if (output.empty()) return -EAGAIN; /* no phone */
         // error format: "/sbin/healthd: Permission denied"
+        cout << "caching ls '" << path_string;
         if (
             output.front().length() > sizeof(PERMISSION_ERR_MSG) &&
-            (!output.front().compare(output.front().length() - sizeof(PERMISSION_ERR_MSG) + 1,
-                                    sizeof(PERMISSION_ERR_MSG) - 1, PERMISSION_ERR_MSG)))
+            (!output.front().compare(
+                output.front().length() - sizeof(PERMISSION_ERR_MSG) + 1,
+                sizeof(PERMISSION_ERR_MSG) - 1,
+                PERMISSION_ERR_MSG)))
         {
+            cout << "' (failed) = ";
+            fileData[path_string].lsOutput.erase();
             fileData[path_string].statOutput.erase();
+            fileData[path_string].noStat = false;
+            cout << output.front() << endl;
         } else {
+            cout << "' = ";
             output_chunk = make_array(output.front());
-            fileData[path_string].statOutput = output.front();
+            fileData[path_string].lsOutput = output.front();
+            cout << output.front() << endl;
+            cache_stat(path_string);
         }
+
         fileData[path_string].timestamp = time(NULL);
     } else{
-        output_chunk = make_array(fileData[path_string].statOutput);
+        output_chunk = make_array(fileData[path_string].lsOutput);
         cout << "from cache " << path << "\n";
     }
-    if (fileData[path_string].statOutput.empty()) {
+    if (fileData[path_string].lsOutput.empty()) {
         // return empty structure - file exists, but no info available
         stbuf->st_mode = S_IFREG;
         return res;
@@ -460,6 +1018,110 @@ static int adb_getattr(const char *path, struct stat *stbuf)
         return -ENOENT;
     }
 
+    // Very old toybox put '?' instead of %t. We need to calcultate uid_offset
+    // now to fall back to ls on that
+    long unsigned int uid_offset = 0;
+    nlink_t st_nlink_ls = atoi(output_chunk[1].c_str());
+    if (st_nlink_ls > 0) uid_offset = 1;
+    else st_nlink_ls = 1;
+
+    bool failed_stat = true;
+    // lsOutput was populated but never statOutput via other fuse verbs
+    if (fileData[path_string].noStat)
+        cache_stat(path_string);
+    if (! (fileData[path_string].statOutput.empty())) {
+        vector<string> output_chunk_stat = make_array(fileData[path_string].statOutput);
+        if (output_chunk_stat.size() == 13) {
+            failed_stat = false;
+            const char * startPtr;
+            char * endPtr;
+            /*
+            struct def :
+            https://pubs.opengroup.org/onlinepubs/007904875/basedefs/sys/stat.h.html
+            types def :
+            https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/sys_types.h.html
+
+            %D %i %f %h %u %g %t %s %b %B %X %Y %Z
+            st_dev st_ino st_mode st_nlink st_uid st_gid st_rdev st_size
+                st_blocks st_blksize st_atime st_mtime st_ctime
+            example for '/system/usr':
+            fd1c 25194110 a1a4 1 0 0 0 7 8 512 1761534769 1761534769 1761534769
+            */
+            for (uint i = 0; i < 13; i++) {
+                startPtr = output_chunk_stat[i].c_str();
+                switch(i) {
+                    case 0: // aDevice ID (fd1c)
+                        stbuf->st_dev = strtoull(startPtr, &endPtr, 16);
+                        break;
+                    case 1: // ino number (25194110)
+                        stbuf->st_ino = strtoull(startPtr, &endPtr, 10);
+                        break;
+                    case 2: // mode (a1a4)
+                        stbuf->st_mode = strtoull(startPtr, &endPtr, 16);
+                        break;
+                    case 3: // number of hard links (1)
+                        stbuf->st_nlink = strtoull(startPtr, &endPtr, 10);
+                        break;
+
+                    // Owners IDs
+                    case 4: // uid (0=root)
+                        stbuf->st_uid = strtoull(startPtr, &endPtr, 10);
+                        break;
+                    case 5: // guid (0=root)
+                        stbuf->st_gid = strtoull(startPtr, &endPtr, 10);
+                        break;
+                    case 6: // (0=normal file)
+                        if (strcmp(startPtr, "?") != 0)
+                            stbuf->st_rdev = strtoull(startPtr, &endPtr, 16);
+                        else if ((stbuf->st_mode & S_IFMT) == S_IFCHR)
+                            stbuf->st_rdev =
+                                atoi(output_chunk[uid_offset + 3].c_str()) * 256
+                                +
+                                atoi(output_chunk[uid_offset + 4].c_str());
+                        else
+                            stbuf->st_rdev = 0;
+                        break;
+
+                    // File sizes
+                    case 7: // (7)
+                        stbuf->st_size = strtoull(startPtr, &endPtr, 10);
+                        break;
+                    case 8:  // number of block (is signed) (8)
+                        stbuf->st_blocks = strtoll(startPtr, &endPtr, 10);
+                        break;
+                    case 9: // block size (should be 512) (512)
+                        stbuf->st_blksize = strtoull(startPtr, &endPtr, 10);
+                        break;
+
+                    // File times
+                    case 10: // time of last access  (1761534769)
+                        stbuf->st_atime = strtoll(startPtr, &endPtr, 10);
+                        break;
+                    case 11: // time of last modification (1761534769)
+                        stbuf->st_mtime = strtoll(startPtr, &endPtr, 10);
+                        break;
+                    case 12: // time of last status change (1761534769)
+                        stbuf->st_ctime = strtoll(startPtr, &endPtr, 10);
+                        break;
+                }
+                if (endPtr == startPtr) {
+                    cout << "Failed parsing stat on " << i << endl;
+                    failed_stat = true;
+                    fileData[path_string].statOutput.erase();
+                    break;
+                }
+            }
+        } else {
+            fileData[path_string].statOutput.erase();
+        }
+    }
+
+    if (! failed_stat)
+        return res;
+
+    if (coreutils_have_stat)
+        cout << "Getting stat data from ls output fall back for '"
+            << path << "'\n";
     //
     // ls -lad explained
     // -rw-rw-r-- root     sdcard_rw   763362 2012-06-22 02:16 file.html
@@ -477,91 +1139,75 @@ static int adb_getattr(const char *path, struct stat *stbuf)
 
     stbuf->st_mode = strmode_to_rawmode(output_chunk[0]); // | 0700
 
-    int uid_offset = 0;
-
-    stbuf->st_nlink = atoi(output_chunk[1].c_str());
-    if (stbuf->st_nlink > 0) uid_offset = 1;
-    else stbuf->st_nlink = 1;
+    stbuf->st_nlink = st_nlink_ls;
 
     foruid = getpwnam(output_chunk[uid_offset + 1].c_str());
     if (foruid)
-	    stbuf->st_uid = foruid->pw_uid;     /* user ID of owner */
+        stbuf->st_uid = foruid->pw_uid;     /* user ID of owner */
     else
-	    stbuf->st_uid = 98; /* 98 has been chosen (poorly) so that it doesn't map to anything */
+        stbuf->st_uid = 98; /* 98 has been chosen (poorly) so that it doesn't map to anything */
 
     forgid = getgrnam(output_chunk[uid_offset + 2].c_str());
     if (forgid)
-	    stbuf->st_gid = forgid->gr_gid;     /* group ID of owner */
+        stbuf->st_gid = forgid->gr_gid;     /* group ID of owner */
     else
-	    stbuf->st_gid = 98;
+        stbuf->st_gid = 98;
 
     //unsigned int device_id;
     //xtoi(output_chunk[6].c_str(),&device_id);
     //stbuf->st_rdev = device_id;    // device ID (if special file)
 
-    int iDate;
+    long unsigned int iDate;
 
     switch (stbuf->st_mode & S_IFMT) {
     case S_IFBLK:
     case S_IFCHR:
-	    stbuf->st_rdev = atoi(output_chunk[uid_offset + 3].c_str()) * 256 +
-                         atoi(output_chunk[uid_offset + 4].c_str());
-	    stbuf->st_size = 0;
-	    iDate = uid_offset + 5;
-	    break;
+        stbuf->st_rdev = atoi(output_chunk[uid_offset + 3].c_str()) * 256 +
+                        atoi(output_chunk[uid_offset + 4].c_str());
+        stbuf->st_size = 0;
+        iDate = uid_offset + 5;
+        break;
 
-	    break;
+        break;
 
     case S_IFREG:
-	    stbuf->st_size = atol(output_chunk[uid_offset + 3].c_str());    /* total size, in bytes */
-	    iDate = uid_offset + 4;
-	    break;
+        stbuf->st_size = atol(output_chunk[uid_offset + 3].c_str());    /* total size, in bytes */
+        iDate = uid_offset + 4;
+        break;
 
     default:
     case S_IFSOCK:
     case S_IFIFO:
     case S_IFLNK:
     case S_IFDIR:
-	    stbuf->st_size = 0;
-	    iDate = uid_offset + 3;
+        stbuf->st_size = 0;
+        iDate = uid_offset + 3;
         if (output_chunk[iDate].find_first_of("-") == string::npos) ++iDate;
-	    break;
+        break;
     }
+
+    time_t now;
+    if (output_chunk.size() >= iDate + 4
+            && (!output_chunk.empty())
+            && output_chunk[iDate + 2].front() == '+'
+            && output_chunk[iDate + 2].back() != '\\')
+        now = convert_str_to_date(
+            output_chunk[iDate],
+            output_chunk[iDate+ 1],
+            output_chunk[iDate + 2]);
+    else
+        now = convert_str_to_date(
+            output_chunk[iDate],
+            output_chunk[iDate+ 1], "");
+    stbuf->st_atime = now;   /* time of last access */
+    stbuf->st_mtime = now;   /* time of last modification */
+    stbuf->st_ctime = now;   /* time of last status change */
+    stbuf->st_ino = 1;      /* inode number, fake. */
 
     // du calculates sizes based on number of 512b blocks
     stbuf->st_blksize = 512;
     stbuf->st_blocks = (stbuf->st_size + 256) / 512;
 
-    //for (int k = 0; k < output_chunk.size(); ++k) cout << output_chunk[k] << " ";
-    //cout << endl;
-
-    vector<string> ymd = make_array(output_chunk[iDate], "-");
-    vector<string> hm = make_array(output_chunk[iDate + 1], ":");
-
-
-    //for (int k = 0; k < ymd.size(); ++k) cout << ymd[k] << " ";
-    //cout << endl;
-    //for (int k = 0; k <  hm.size(); ++k) cout <<  hm[k] << " ";
-    //cout << endl;
-    struct tm ftime;
-    ftime.tm_year = atoi(ymd[0].c_str()) - 1900;
-    ftime.tm_mon  = atoi(ymd[1].c_str()) - 1;
-    ftime.tm_mday = atoi(ymd[2].c_str());
-    ftime.tm_hour = atoi(hm[0].c_str());
-    ftime.tm_min  = atoi(hm[1].c_str());
-    ftime.tm_sec  = 0;
-    ftime.tm_isdst = -1;
-    time_t now = mktime(&ftime);
-    //cout << "after mktime" << endl;
-
-    //long now = time(0);
-
-    stbuf->st_atime = now;   /* time of last access */
-    //stbuf->st_atime = atol(output_chunk[11].c_str());   /* time of last access */
-    stbuf->st_mtime = now;   /* time of last modification */
-    //stbuf->st_mtime = atol(output_chunk[12].c_str());   /* time of last modification */
-    stbuf->st_ctime = now;   /* time of last status change */
-    //stbuf->st_ctime = atol(output_chunk[13].c_str());   /* time of last status change */
     return res;
 }
 
@@ -569,7 +1215,8 @@ static int adb_getattr(const char *path, struct stat *stbuf)
 size_t find_nth(int n, const string& substr, const string& corpus) {
     size_t p = 0;
     while (n--) {
-        if ((( p = corpus.find_first_of(substr, p) )) == string::npos) return string::npos;
+        if ((( p = corpus.find_first_of(substr, p) )) == string::npos)
+            return string::npos;
         p = corpus.find_first_not_of(substr, p);
     }
     return p;
@@ -596,7 +1243,8 @@ static int adb_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
     shell_escape_path(path_string);
 
     queue<string> output;
-    string command = "ls -l -a '";
+    // In old Android versions -ll is treated as -l. We handle that later.
+    string command = "ls -lla '";
     command.append(path_string);
     command.append("'");
     output = adb_shell(command);
@@ -615,30 +1263,61 @@ static int adb_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
                                             sizeof(PERMISSION_ERR_MSG) - 1, PERMISSION_ERR_MSG))) {
                     size_t nameStart = output.front().rfind("/") + 1;
                     const string& fname_l = output.front().substr(nameStart, output.front().find("' ") - nameStart);
-                    cout << "Adding file:" << fname_l << ":" << endl;
+                    if (fname_l == "." || fname_l == "..")
+                        continue;
+                    cout << "Adding file: '" << fname_l << "':" << endl;
                     filler(buf, fname_l.c_str(), NULL, 0);
                     const string& path_string_c = path_string
                         + (path_string == "/" ? "" : "/") + fname_l;
 
-                    cout << "caching " << path_string_c << " = " << output.front() <<  endl;
+                    cout << "caching ls '" << path_string_c << "' (failed) = " << output.front() <<  endl;
+                    fileData[path_string_c].lsOutput.erase();
                     fileData[path_string_c].statOutput.erase();
+                    fileData[path_string_c].noStat = false;
                     fileData[path_string_c].timestamp = time(NULL);
-                    cout << "cached " << endl;
                 }
             } else {
-                // Start of filename = `ls -la` time separator + 4
-                size_t nameStart = output.front().find_first_of(":") + 4;
+                size_t hourSeparatorStart = output.front().find_first_of(":");
+                vector<string> restOfLsOutput = make_array(output.front().substr(hourSeparatorStart));
+                size_t nameStart;
+                if (ranges::count(restOfLsOutput[0], ':') == 2)
+                    /*
+                    Start of filename =
+                        `ls -lla` time separator + two field
+                            (rest of time + timezone)
+                    restOfLsOutput =
+                        ":14:12.895999998 +0200 filename"
+                    restOfLsOutput =
+                        ":14:12.895999998 +0200 filename"
+                    So we skip the rest of the time, the timezone and spaces
+                    */
+                    nameStart = hourSeparatorStart
+                        + restOfLsOutput[0].size()
+                        + restOfLsOutput[1].size() + 2;
+                else
+                    /*
+                    if ls does not supports the '-ll' (like very old Androids)
+                    we can detect it via the number of : in the time
+                    in case of ls -l and not ls -ll it's =
+                        `ls -la` hourSeparatorStart + 4
+                    */
+                    nameStart = hourSeparatorStart + 4;
+
                 const string& fname_l = output.front().substr(nameStart);
                 const string fname_n = fname_l.substr(0, fname_l.find(" -> "));
-                cout << "Adding file:" << fname_n <<":" << endl;
+                cout << "Adding file: '" << fname_n <<"':" << endl;
                 filler(buf, fname_n.c_str(), NULL, 0);
                 const string path_string_c = path_string
                     + (path_string == "/" ? "" : "/") + fname_n;
 
-                cout << "caching " << path_string_c << " = " << output.front() <<  endl;
-                fileData[path_string_c].statOutput = output.front();
+                cout << "caching ls '" << path_string_c << "' = "
+                    << output.front() <<  endl;
+                fileData[path_string_c].lsOutput = output.front();
+                bool noStat = NO_RECENT_CACHE(path_string_c);
+                fileData[path_string_c].noStat = noStat;
+                if (noStat)
+                    fileData[path_string_c].statOutput.erase();
                 fileData[path_string_c].timestamp = time(NULL);
-                cout << "cached " << endl;
             }
         }
         output.pop();
@@ -668,7 +1347,7 @@ static int adb_open(const char *path, struct fuse_file_info *fi)
     cout << "-- adb_open --" << path_string << " " << local_path_string << "\n";
     if (!fileTruncated[path_string]){
         queue<string> output;
-        string command = "ls -l -a -d '";
+        string command = "ls -lad '";
         command.append(path_string);
         command.append("'");
         cout << command<<"\n";
@@ -769,9 +1448,9 @@ static int adb_release(const char *path, struct fuse_file_info *fi) {
     int fd = fi->fh;
     filePendingWrite.erase(filePendingWrite.find(fd));
     close(fd);
-    
+
     // remove local copy
-    unlink(local_path_string.c_str());    
+    unlink(local_path_string.c_str());
     return 0;
 }
 
@@ -781,6 +1460,9 @@ static int adb_access(const char *path, int mask) {
 }
 
 static int adb_utimens(const char *path, const struct timespec ts[2]) {
+    if (disable_utimens)
+        return -ENOSYS;
+
     string path_string;
     path_string.assign(path);
     fileData[path_string].timestamp = fileData[path_string].timestamp + 50;
@@ -809,22 +1491,35 @@ static int adb_utimens(const char *path, const struct timespec ts[2]) {
     if (!set_atime && !set_mtime)
         return 0;
     string command = "";
-    if (set_atime) {
-        command.append("touch -a -d ");
-        command.append(format_touch_time(atime, touch_gnu_mode));
+    command.append(forced_coreutils_touch);
+    if (coreutils_touch == BUSYBOX) {
+        if (!set_mtime)
+            return 0;
+        // Busybox only supports changing last modification datetime
+        command.append("touch -d ");
+        command.append(format_touch_time(mtime));
         command.append(" '");
         command.append(path_string);
         command.append("'");
-        if (set_mtime)
-            command.append(" && ");
+    } else {
+        if (set_atime) {
+            command.append("touch -a ");
+            command.append(format_touch_time(atime));
+            command.append(" '");
+            command.append(path_string);
+            command.append("'");
+            if (set_mtime)
+                command.append(" && ");
+        }
+        if (set_mtime) {
+            command.append("touch -m ");
+            command.append(format_touch_time(mtime));
+            command.append(" '");
+            command.append(path_string);
+            command.append("'");
+        }
     }
-    if (set_mtime) {
-        command.append("touch -m -d ");
-        command.append(format_touch_time(mtime, touch_gnu_mode));
-        command.append(" '");
-        command.append(path_string);
-        command.append("'");
-    }
+
     cout << command<<"\n";
     queue<string> output;
     output = adb_shell(command, true);
@@ -834,22 +1529,35 @@ static int adb_utimens(const char *path, const struct timespec ts[2]) {
             cout << output.front() << "\n";
             output.pop();
         }
-        bool date_failed = front.length() > sizeof(TOUCH_TOYBOX_GNU_DATE_ERR_MSG)
-                && !front.compare(0, sizeof(TOUCH_TOYBOX_GNU_DATE_ERR_MSG) - 1, TOUCH_TOYBOX_GNU_DATE_ERR_MSG);
-        date_failed = date_failed || (front.length() > sizeof(TOUCH_BUSYBOX_GNU_DATE_ERR_MSG)
-                && !front.compare(0, sizeof(TOUCH_BUSYBOX_GNU_DATE_ERR_MSG) - 1, TOUCH_BUSYBOX_GNU_DATE_ERR_MSG));
+        bool date_failed =
+                front.length() > sizeof(TOUCH_TOYBOX_GNU_DATE_ERR_MSG)
+                && !front.compare(
+                    0,
+                    sizeof(TOUCH_TOYBOX_GNU_DATE_ERR_MSG) - 1,
+                    TOUCH_TOYBOX_GNU_DATE_ERR_MSG);
+        date_failed =
+            date_failed
+            || (front.length() > sizeof(TOUCH_BUSYBOX_GNU_DATE_ERR_MSG)
+                && !front.compare(
+                    0,
+                    sizeof(TOUCH_BUSYBOX_GNU_DATE_ERR_MSG) - 1,
+                    TOUCH_BUSYBOX_GNU_DATE_ERR_MSG));
 
         if (date_failed) {
             if (!touch_gnu_mode)
                 return -ENOSYS;
 
-            cout << "Touch doesn't seems to support GNU dates with nanoseconds support. Switching to legacy mode.\n";
+            cout << "Touch doesn't seems to support GNU dates with "
+            << "nanoseconds support. Switching to legacy mode." << endl;
             touch_gnu_mode = false;
             return adb_utimens(path, ts);
         }
     }
 
-    // If we forgot to mount -o rescan then we can remount and touch to trigger the scan.
+    cache_stat(path_string);
+
+    // If we forgot to mount -o rescan then we can remount and touch
+    // to trigger the scan.
     if (adbfs_conf.rescan) adb_rescan_file(path_string);
 
     return 0;
@@ -885,7 +1593,8 @@ static int adb_truncate(const char *path, off_t size) {
 
     invalidateCache(path_string);
 
-    cout << "truncate[path=" << local_path_string << "][size=" << size << "]" << endl;
+    cout << "truncate[path="
+    << local_path_string << "][size=" << size << "]" << endl;
 
     return truncate(local_path_string.c_str(),size);
 }
@@ -1023,14 +1732,14 @@ static int adb_readlink(const char *path, char *buf, size_t size)
     queue<string> output;
 
     // get the number of slashes in the path
-    int num_slashes, ii;
+    long num_slashes;
+    long unsigned int ii;
     for (num_slashes = ii = 0; ii < strlen(path); ii++)
         if (path[ii] == '/')
             num_slashes++;
     if (num_slashes >= 1) num_slashes--;
 
-    if (fileData.find(path_string) ==  fileData.end()
-	|| fileData[path_string].timestamp + 30 < time(NULL)) {
+    if (NO_RECENT_CACHE(path_string)) {
         string command = "ls -l -a -d '";
         command.append(path_string);
         command.append("'");
@@ -1039,19 +1748,29 @@ static int adb_readlink(const char *path, char *buf, size_t size)
             return -EINVAL;
         // error format: "/sbin/healthd: Permission denied"
 
+        cout << "caching ls '" << path_string;
         if ((output.front().length() > sizeof(PERMISSION_ERR_MSG)) &&
            (!output.front().compare(output.front().length() - sizeof(PERMISSION_ERR_MSG) + 1,
                                     sizeof(PERMISSION_ERR_MSG) - 1, PERMISSION_ERR_MSG)))
         {
+            cout << "' (failed) = ";
+            fileData[path_string].lsOutput.erase();
             fileData[path_string].statOutput.erase();
+            fileData[path_string].noStat = false;
         } else {
-            fileData[path_string].statOutput = output.front();
+            cout << "' = ";
+            fileData[path_string].lsOutput = output.front();
+            bool noStat = NO_RECENT_CACHE(path_string);
+            fileData[path_string].noStat = noStat;
+            if (noStat)
+                fileData[path_string].statOutput.erase();
         }
+        cout << output.front() <<  endl;
         fileData[path_string].timestamp = time(NULL);
     } else{
         cout << "from cache " << path << "\n";
     }
-    string &res = fileData[path_string].statOutput;
+    string &res = fileData[path_string].lsOutput;
     if (res.empty()) {
         // file exists, but no info available
         return -EINVAL;
@@ -1115,6 +1834,7 @@ int main(int argc, char *argv[])
     adbfs_oper.unlink = adb_unlink;
     adbfs_oper.readlink = adb_readlink;
     adb_shell("ls");
+    initAndroidInfos();
 
     struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
     memset(&adbfs_conf, 0, sizeof(adbfs_conf));

--- a/utils.h
+++ b/utils.h
@@ -180,17 +180,30 @@ queue<string> exec_command(const string& command)
 }
 
 /**
-   Convert timespec to GNU touch parameter format
-   https://www.gnu.org/software/coreutils/manual/html_node/General-date-syntax.html
-   Toybox's touch used on Android supports the GNU extension for the nanoseconds : "@%s.%N"
+   Convert timespec to touch parameter format
 
-   @param timespec the time to be converted
+   gnu_format allows to specify up to nanoseconds.
+   https://www.gnu.org/software/coreutils/manual/html_node/General-date-syntax.html
+   Toybox's touch used on Android supports the GNU extension for the nanoseconds since 0.8.1 : "@%s.%N"
+   Toybox was begin used instead of Busybox in Android 6
+
+   @param t the time to be converted
+   @param gnu_format if touch supports GNU time format
  */
-static string format_gnu_touch_time(const struct timespec& t) {
-    ostringstream ss;
-    ss << "@"
-       << t.tv_sec
-       << "."
-       << setw(9) << setfill('0') << t.tv_nsec;
-    return ss.str();
+static string format_touch_time(const struct timespec& t, bool gnu_format) {
+    if (gnu_format) {
+        ostringstream ss;
+        ss << "@"
+            << t.tv_sec
+            << "."
+            << setw(9) << setfill('0') << t.tv_nsec;
+            return ss.str();
+    } else {
+        char timebuf[32];
+        struct tm _tm;
+        localtime_r(&(t.tv_sec), &_tm);
+        strftime(timebuf, sizeof(timebuf), "%Y-%m-%dT%H:%M:%S", &_tm);
+        string out = timebuf;
+        return out;
+    }
 }

--- a/utils.h
+++ b/utils.h
@@ -48,6 +48,8 @@
 #include <vector>
 #include <map>
 #include <unistd.h>
+#include <ctime>
+#include <iomanip>
 
 using namespace std;
 
@@ -177,3 +179,18 @@ queue<string> exec_command(const string& command)
     return output;
 }
 
+/**
+   Convert timespec to GNU touch parameter format
+   https://www.gnu.org/software/coreutils/manual/html_node/General-date-syntax.html
+   Toybox's touch used on Android supports the GNU extension for the nanoseconds : "@%s.%N"
+
+   @param timespec the time to be converted
+ */
+static string format_gnu_touch_time(const struct timespec& t) {
+    ostringstream ss;
+    ss << "@"
+       << t.tv_sec
+       << "."
+       << setw(9) << setfill('0') << t.tv_nsec;
+    return ss.str();
+}

--- a/utils.h
+++ b/utils.h
@@ -185,25 +185,25 @@ queue<string> exec_command(const string& command)
    gnu_format allows to specify up to nanoseconds.
    https://www.gnu.org/software/coreutils/manual/html_node/General-date-syntax.html
    Toybox's touch used on Android supports the GNU extension for the nanoseconds since 0.8.1 : "@%s.%N"
-   Toybox was begin used instead of Busybox in Android 6
+   Toybox was begin used instead of Busybox in Android 6.
 
    @param t the time to be converted
    @param gnu_format if touch supports GNU time format
  */
 static string format_touch_time(const struct timespec& t, bool gnu_format) {
+    ostringstream ss;
     if (gnu_format) {
-        ostringstream ss;
         ss << "@"
             << t.tv_sec
             << "."
             << setw(9) << setfill('0') << t.tv_nsec;
-            return ss.str();
+        return ss.str();
     } else {
-        char timebuf[32];
-        struct tm _tm;
-        localtime_r(&(t.tv_sec), &_tm);
-        strftime(timebuf, sizeof(timebuf), "%Y-%m-%dT%H:%M:%S", &_tm);
-        string out = timebuf;
-        return out;
+        // It could be possible to convert here the timezone instead of creating a more complex shell comamand.
+        ss << "`date -ud "
+            << "@" << t.tv_sec  << "."
+            << setw(9) << setfill('0') << t.tv_nsec
+            << " +%Y-%m-%dT%H:%M:%S`";
     }
+    return ss.str();
 }

--- a/utils.h
+++ b/utils.h
@@ -55,7 +55,18 @@ using namespace std;
 
 struct fileCache{
     time_t timestamp;
+    string lsOutput;
     string statOutput;
+    bool noStat;
+};
+
+// Didn't tested bellow Android 4.1 alias Jelly Bean
+enum coreutils_type {
+    UNKOWN,
+    TOOLBOX_OLD, // Android 4.1 (Jelly Bean) -> 4.3 (Jelly Bean)
+    TOOLBOX, // Android 4.4 (KitKat) -> Android 5.1 (Lolipop)
+    TOYBOX, // Android 6 (Marshmallow) -> now
+    BUSYBOX, // if custom
 };
 
 queue<string> exec_command(const string&);
@@ -177,33 +188,4 @@ queue<string> exec_command(const string& command)
     pclose( fp );
 
     return output;
-}
-
-/**
-   Convert timespec to touch parameter format
-
-   gnu_format allows to specify up to nanoseconds.
-   https://www.gnu.org/software/coreutils/manual/html_node/General-date-syntax.html
-   Toybox's touch used on Android supports the GNU extension for the nanoseconds since 0.8.1 : "@%s.%N"
-   Toybox was begin used instead of Busybox in Android 6.
-
-   @param t the time to be converted
-   @param gnu_format if touch supports GNU time format
- */
-static string format_touch_time(const struct timespec& t, bool gnu_format) {
-    ostringstream ss;
-    if (gnu_format) {
-        ss << "@"
-            << t.tv_sec
-            << "."
-            << setw(9) << setfill('0') << t.tv_nsec;
-        return ss.str();
-    } else {
-        // It could be possible to convert here the timezone instead of creating a more complex shell comamand.
-        ss << "`date -ud "
-            << "@" << t.tv_sec  << "."
-            << setw(9) << setfill('0') << t.tv_nsec
-            << " +%Y-%m-%dT%H:%M:%S`";
-    }
-    return ss.str();
 }


### PR DESCRIPTION
Hello,
Here is a PR that implements all stat attributes for adb_getattr and fixes my last PR #76 utimens for all cases.

It handles :
- Exotic and old coreutils installed with dynamic detection and switching for the best available.
- From Android 4.1 to the latest (some features are limited on some versions).
- Automatic fallback to ls with added seconds and timezone support if stat does not work
- Caching stat output to avoid calling stat each time
- Handling of timezone (old Android without anytime zones, different timezone between the computer and the Android device and summer time)

Tested on :
- Samsung Fold 7 (Android 16)
- OnePlus 9 (Android 14)
- LG G6 (Android 9)
- Inside AVD : Android from 4.1 (no images older available directly inside AVD) to 9

For those devices I tested that a touch and a stat always output the same information and that other features are working.
I used my modification to sync to the second all my files of all my devices to be able to sync on my NAS.

To be noted : from Android 6 to 8 utimens cannot work due to a bug in the old toybox coreutils (details in the code comments). They is no workaround possible. The only way is a rooted device and  busybox for example installed which will be automatically chosen by the detections capabilities.

Since it comes at a cost of performance (all file must be individually stated) we could imagine some solutions :
- User option to fallback to the incomplete ls output.
- Maintain a `adb shell` session continuously.
- Trying to stat all files in one line when exploring a folder.