### PR TITLE
MacOS: add fuse-t support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-CXXFLAGS=-Wall $(shell pkg-config fuse --cflags)
-LDFLAGS=-Wall $(shell pkg-config fuse --libs)
+FUSE_PKG ?= fuse
+CXXFLAGS=-Wall $(if $(filter fuse-t,$(FUSE_PKG)),-D_FILE_OFFSET_BITS=64) $(shell pkg-config $(FUSE_PKG) --cflags)
+LDFLAGS=-Wall $(shell pkg-config $(FUSE_PKG) --libs)
 
 TARGET=adbfs
 DESTDIR?=/

--- a/README.md
+++ b/README.md
@@ -39,10 +39,21 @@ Have fun!
 
 ## MacOS
 
-Install adb and fuse
+Install adb and fuse. You have two options for FUSE:
+
+**Option A: macfuse**
 
     brew install --cask android-platform-tools
     brew install --cask macfuse
+
+**Option B: fuse-t**
+
+    brew install --cask android-platform-tools
+    brew install macos-fuse-t/homebrew-cask/fuse-t
+
+If using fuse-t, build with:
+
+    make FUSE_PKG=fuse-t
 
 Check access to phone through adb
 


### PR DESCRIPTION
On MacOS, add fuse-t as another alternative fuse.